### PR TITLE
feat(spawn): honor cwd parameter in /api/sessions/spawn

### DIFF
--- a/server.py
+++ b/server.py
@@ -3555,8 +3555,12 @@ def _slugify(text, max_len=40):
     return slug[:max_len].rstrip("-")
 
 
-def spawn_session(prompt, name=None):
-    """Spawn a headless Claude Code session and return tracking info."""
+def spawn_session(prompt, name=None, cwd=None):
+    """Spawn a headless Claude Code session and return tracking info.
+
+    If `cwd` is provided, the spawned subprocess runs there; otherwise it
+    inherits CCC's REPO_ROOT (backwards-compatible default).
+    """
     # Always slugify — name may come from firstSentence(body) and contain
     # filesystem-hostile chars like quotes, colons, slashes.
     session_name = _slugify(name or prompt)
@@ -3576,13 +3580,14 @@ def spawn_session(prompt, name=None):
         "--name", session_name,
     ]
 
+    spawn_cwd = cwd if cwd else str(REPO_ROOT)
     log_fh = open(log_path, "w")
     proc = subprocess.Popen(
         cmd,
         stdin=subprocess.PIPE,
         stdout=log_fh,
         stderr=subprocess.STDOUT,
-        cwd=str(REPO_ROOT),
+        cwd=spawn_cwd,
         start_new_session=True,
     )
 
@@ -6145,11 +6150,17 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
                 payload = {}
             prompt = (payload.get("prompt") or "").strip()
             name = (payload.get("name") or "").strip() or None
+            cwd_raw = payload.get("cwd")
+            cwd = cwd_raw.strip() if isinstance(cwd_raw, str) else None
             if not prompt:
-                self.send_json({"ok": False, "error": "missing prompt"})
+                self.send_json({"ok": False, "error": "missing prompt"}, 400)
+            elif cwd and not os.path.isabs(cwd):
+                self.send_json({"ok": False, "error": f"cwd must be an absolute path: {cwd}"}, 400)
+            elif cwd and not os.path.isdir(cwd):
+                self.send_json({"ok": False, "error": f"cwd does not exist or is not a directory: {cwd}"}, 400)
             else:
                 try:
-                    self.send_json(spawn_session(prompt, name=name))
+                    self.send_json(spawn_session(prompt, name=name, cwd=cwd or None))
                 except Exception as e:
                     self.send_json({"ok": False, "error": str(e)}, 500)
         elif re.match(r"^/api/sessions/spawned/\d+/inject$", path):


### PR DESCRIPTION
## Summary
- `POST /api/sessions/spawn` silently ignored a `cwd` field in the JSON body — spawned sessions always inherited CCC's own `REPO_ROOT`. Inconsistent with `resume_session_headless`, which already respects a per-session cwd (`server.py:3664`).
- Adds an optional `cwd` kwarg to `spawn_session()` (defaults to `REPO_ROOT`, so existing callers are unaffected) and reads/validates `cwd` in the route handler.
- Validation: when supplied, `cwd` must be an absolute path and must exist. Otherwise returns `400` with a clear error rather than silently spawning in the default dir.

## How this surfaced
A sibling Claude session in `/Users/amirfish/MyOfficeMgr` POSTed `{"prompt": "...", "cwd": "/Users/amirfish/Kneaded.AI"}` and was silently spawned in CCC's working directory instead of the requested target. The fix makes spawn behave the same way resume already does.

## Test plan
- [x] Syntax: `python3 -c "import ast; ast.parse(open('server.py').read())"`
- [x] Happy path: `POST {prompt, cwd:"/tmp"}` → spawned session's init event reports `"cwd":"/private/tmp"`.
- [x] Negative: `POST {prompt, cwd:"/nonexistent/path"}` → `400 {"error": "cwd does not exist or is not a directory: ..."}`.
- [x] Negative: `POST {prompt, cwd:"tmp"}` (relative) → `400 {"error": "cwd must be an absolute path: tmp"}`.
- [x] Regression: `POST {prompt}` (no cwd) → spawns in CCC's `REPO_ROOT` as before.
- [x] Negative: `POST {}` → `400 {"error": "missing prompt"}` (status hardened from default to 400 for consistency with the new validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)