### PR TITLE
feat(bug-report): in-app bug reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `amirfish1/claude-command-center` via `gh issue create`. If `gh` is
   missing or fails, the modal renders the issue markdown so the user can
   copy it to the clipboard and file the report manually. New endpoint:
-  `POST /api/bug-report`. Pattern adapted from BookYourMat.
+  `POST /api/bug-report`. Pattern adapted from BookYourMat. (#5)
 
 ## [0.1.2] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- In-app bug reporting — a "Report a bug" link in the topbar opens a modal
+  that auto-attaches CCC version, browser user-agent, and the currently
+  selected session id, then files a GitHub issue (label `bug`) against
+  `amirfish1/claude-command-center` via `gh issue create`. If `gh` is
+  missing or fails, the modal renders the issue markdown so the user can
+  copy it to the clipboard and file the report manually. New endpoint:
+  `POST /api/bug-report`. Pattern adapted from BookYourMat.
+
 ## [0.1.2] - 2026-04-24
 
 ### Added

--- a/server.py
+++ b/server.py
@@ -389,6 +389,109 @@ def _self_update():
     return {"ok": True, "new_sha": (sha or "").strip()}
 
 
+# ── In-app bug reporting ───────────────────────────────────────────────
+# The UI surfaces a "Report a bug" link in the topbar that opens a small
+# modal (title + description + auto-collected context). On submit, the
+# client posts to /api/bug-report; the handler shells out to `gh issue
+# create` against amirfish1/claude-command-center. If `gh` isn't
+# available we return the rendered markdown so the UI can offer a
+# copy-to-clipboard fallback for manual filing.
+_BUG_REPORT_REPO = "amirfish1/claude-command-center"
+
+
+def _build_bug_report_body(description, ccc_version, user_agent, session_id):
+    """Render the GitHub issue body (markdown). Pure — no I/O — so it's
+    cheap to also return on the failure path for clipboard fallback."""
+    lines = [
+        "## Description",
+        "",
+        description.strip(),
+        "",
+        "## Context",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| **CCC version** | `{ccc_version or '—'}` |",
+        f"| **Session** | `{session_id or '—'}` |",
+        f"| **User agent** | `{user_agent or '—'}` |",
+        "",
+        "_Reported via the in-app Report a bug feature._",
+    ]
+    return "\n".join(lines)
+
+
+def _create_bug_report_issue(payload):
+    """Validate the payload, build a GitHub issue, file it via `gh`.
+
+    Returns one of:
+      {ok: True,  url: "https://github.com/.../issues/N", number: N}
+      {ok: False, error: "...",  markdown: "..."}   # gh missing / failed
+      {ok: False, error: "..."}                     # validation failure
+    The `markdown` key on the failure path lets the client offer a
+    copy-to-clipboard fallback so the user can file it manually.
+    """
+    title = (payload.get("title") or "").strip()
+    description = (payload.get("description") or "").strip()
+    if not title:
+        return {"ok": False, "error": "title is required"}
+    if not description:
+        return {"ok": False, "error": "description is required"}
+    # Cap title at GitHub's 256 char limit with a generous safety margin so
+    # we surface a clean error rather than a truncated one from gh.
+    if len(title) > 200:
+        title = title[:200].rstrip() + "…"
+
+    ccc_version = (payload.get("ccc_version") or "").strip() or __version__
+    user_agent = (payload.get("user_agent") or "").strip()
+    session_id = (payload.get("session_id") or "").strip()
+
+    body = _build_bug_report_body(description, ccc_version, user_agent, session_id)
+    fallback_md = f"## {title}\n\n{body}"
+
+    if not _which("gh"):
+        return {
+            "ok": False,
+            "error": "gh CLI not found on PATH — copy the markdown and file the issue manually.",
+            "markdown": fallback_md,
+            "repo_url": f"https://github.com/{_BUG_REPORT_REPO}/issues/new",
+        }
+
+    try:
+        # `gh issue create` prints the issue URL on stdout when it succeeds.
+        # We pipe body via --body-file=- so we don't have to worry about
+        # arbitrary user input being interpreted by the shell — there is
+        # no shell (subprocess.run with a list).
+        proc = subprocess.run(
+            ["gh", "issue", "create",
+             "-R", _BUG_REPORT_REPO,
+             "--label", "bug",
+             "--title", title,
+             "--body-file", "-"],
+            input=body,
+            capture_output=True, text=True, timeout=20,
+        )
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "gh issue create timed out", "markdown": fallback_md}
+    except (OSError, subprocess.SubprocessError) as e:
+        return {"ok": False, "error": f"gh failed to launch: {e}", "markdown": fallback_md}
+
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip()[:400]
+        return {
+            "ok": False,
+            "error": err or f"gh issue create exited {proc.returncode}",
+            "markdown": fallback_md,
+            "repo_url": f"https://github.com/{_BUG_REPORT_REPO}/issues/new",
+        }
+
+    url = (proc.stdout or "").strip().splitlines()[-1] if proc.stdout else ""
+    number = None
+    m = re.search(r"/issues/(\d+)", url)
+    if m:
+        number = int(m.group(1))
+    return {"ok": True, "url": url, "number": number}
+
+
 def _schedule_restart(delay=0.5):
     """Arm an os.execvp() that replaces this process with a fresh
     `python server.py` after `delay` seconds. Called AFTER the HTTP response
@@ -5768,6 +5871,27 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
                 except Exception:
                     pass
                 _schedule_restart()
+            return
+        if path == "/api/bug-report":
+            # Submit a bug report as a GitHub issue against the CCC repo.
+            # Returns {ok:true,url,number} on success; on failure returns
+            # {ok:false,error,markdown,repo_url} so the UI can offer a
+            # copy-to-clipboard fallback for manual filing.
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length) if length > 0 else b""
+            try:
+                payload = json.loads(body) if body else {}
+            except json.JSONDecodeError:
+                payload = {}
+            result = _create_bug_report_issue(payload)
+            # Validation errors (missing title/description) → 400. Anything
+            # else (gh missing, gh failed, network) → 200 with ok:false so
+            # the client can still render the fallback markdown without a
+            # generic browser error page.
+            if not result.get("ok") and not result.get("markdown"):
+                self.send_json(result, 400)
+            else:
+                self.send_json(result)
             return
         if path == "/api/fs/pick-folder":
             # Open the OS-native folder chooser and return the picked absolute

--- a/static/index.html
+++ b/static/index.html
@@ -1196,6 +1196,49 @@
     white-space: pre-wrap; word-break: break-word; }
   .upd-error.visible { display: block; }
 
+  /* ── Bug-report link + modal ─────────────────────────────────
+     Subtle "Report a bug" link in the topbar. Opens a modal that
+     reuses the .upd-overlay / .upd-dialog / .upd-btn shells. */
+  .bug-link {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 3px 8px; margin-left: 8px;
+    background: transparent; color: var(--text-muted);
+    border: 1px solid transparent; border-radius: 999px;
+    font-size: 11px; font-family: inherit; cursor: pointer;
+    letter-spacing: 0.2px; white-space: nowrap;
+    transition: background 0.12s ease-out, color 0.12s ease-out;
+  }
+  .bug-link:hover { background: rgba(255,255,255,0.04); color: var(--text); }
+  .bug-input { width: 100%; box-sizing: border-box;
+    padding: 7px 10px; border-radius: 6px;
+    border: 1px solid var(--border); background: var(--bg);
+    color: var(--text); font-family: inherit; font-size: 13px;
+    outline: none; }
+  .bug-input:focus { border-color: var(--accent); }
+  .bug-textarea { min-height: 110px; resize: vertical; line-height: 1.45; }
+  .bug-label { font-size: 11px; color: var(--text-muted);
+    text-transform: uppercase; letter-spacing: 0.5px;
+    margin-bottom: 6px; display: block; }
+  .bug-meta { font-size: 11px; color: var(--text-muted);
+    background: var(--bg); border: 1px solid var(--border);
+    border-radius: 6px; padding: 8px 10px; line-height: 1.5;
+    word-break: break-all; }
+  .bug-meta code { font-family: 'SF Mono',SFMono-Regular,Consolas,monospace;
+    font-size: 10.5px; color: var(--text); }
+  .bug-success { font-size: 12px; color: var(--green, #3fb950);
+    background: rgba(63,185,80,0.1); border: 1px solid rgba(63,185,80,0.3);
+    border-radius: 6px; padding: 8px 10px; display: none; }
+  .bug-success.visible { display: block; }
+  .bug-fallback {
+    font-size: 12px; color: var(--text-muted);
+    background: var(--bg); border: 1px solid var(--border);
+    border-radius: 6px; padding: 8px 10px; display: none;
+    white-space: pre-wrap; word-break: break-word;
+    max-height: 180px; overflow: auto;
+    font-family: 'SF Mono',SFMono-Regular,Consolas,monospace;
+  }
+  .bug-fallback.visible { display: block; }
+
   /* Backlog column — no longer sticky, scrolls with the rest */
   /* Reuse kanban column/card styles in split mode */
   .kanban-board-split .kanban-column,
@@ -1873,6 +1916,9 @@
       <span class="upd-pill-dot"></span>
       <span id="updPillText">Update available</span>
     </button>
+    <button type="button" id="bugReportLink" class="bug-link" title="Report a bug or request a feature. Files a GitHub issue against amirfish1/claude-command-center.">
+      &#9873; Report a bug
+    </button>
     <div id="setupBanner" class="ccc-setup-banner"></div>
   </div>
 
@@ -2092,6 +2138,45 @@
       <div class="upd-actions">
         <button type="button" class="upd-btn" id="updLaterBtn">Later</button>
         <button type="button" class="upd-btn upd-primary" id="updNowBtn">Update now</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Bug-report modal. Opened from #bugReportLink. POSTs to
+       /api/bug-report which shells out to `gh issue create` against
+       amirfish1/claude-command-center. If gh is missing or fails, the
+       handler returns a rendered markdown blob and we offer a
+       copy-to-clipboard fallback. -->
+  <div id="bugReportModal" class="upd-overlay" role="dialog" aria-modal="true" aria-labelledby="bugReportTitle">
+    <div class="upd-backdrop" id="bugReportBackdrop"></div>
+    <div class="upd-dialog" style="width:min(560px,92vw);">
+      <div class="upd-title" id="bugReportTitle">Report a bug</div>
+      <div class="upd-versions">
+        Files a GitHub issue against
+        <strong>amirfish1/claude-command-center</strong>. The context block
+        below is auto-attached to the report.
+      </div>
+      <div>
+        <label class="bug-label" for="bugReportTitleInput">Title</label>
+        <input type="text" id="bugReportTitleInput" class="bug-input" maxlength="200"
+               placeholder="One-line summary of the bug or feature request" />
+      </div>
+      <div>
+        <label class="bug-label" for="bugReportDescInput">Description</label>
+        <textarea id="bugReportDescInput" class="bug-input bug-textarea"
+                  placeholder="What did you see? What did you expect? Steps to reproduce…"></textarea>
+      </div>
+      <div>
+        <label class="bug-label">Auto-attached context</label>
+        <div class="bug-meta" id="bugReportMeta">Loading…</div>
+      </div>
+      <div class="upd-error" id="bugReportError"></div>
+      <div class="bug-success" id="bugReportSuccess"></div>
+      <div class="bug-fallback" id="bugReportFallback"></div>
+      <div class="upd-actions">
+        <button type="button" class="upd-btn" id="bugReportCancelBtn">Cancel</button>
+        <button type="button" class="upd-btn" id="bugReportCopyBtn" style="display:none;">Copy markdown</button>
+        <button type="button" class="upd-btn upd-primary" id="bugReportSubmitBtn">Send report</button>
       </div>
     </div>
   </div>
@@ -7574,6 +7659,177 @@
       }
     } catch (_) { /* silent — the pill just stays hidden */ }
   })();
+
+  // ── In-app bug reporting ────────────────────────────────────────
+  // Topbar link → modal → POST /api/bug-report → server shells out
+  // to `gh issue create`. On gh failure the handler returns the
+  // rendered markdown so we can offer a copy-to-clipboard fallback.
+  const $bugLink = document.getElementById('bugReportLink');
+  const $bugModal = document.getElementById('bugReportModal');
+  const $bugBackdrop = document.getElementById('bugReportBackdrop');
+  const $bugTitleInput = document.getElementById('bugReportTitleInput');
+  const $bugDescInput = document.getElementById('bugReportDescInput');
+  const $bugMeta = document.getElementById('bugReportMeta');
+  const $bugError = document.getElementById('bugReportError');
+  const $bugSuccess = document.getElementById('bugReportSuccess');
+  const $bugFallback = document.getElementById('bugReportFallback');
+  const $bugCancelBtn = document.getElementById('bugReportCancelBtn');
+  const $bugSubmitBtn = document.getElementById('bugReportSubmitBtn');
+  const $bugCopyBtn = document.getElementById('bugReportCopyBtn');
+  let bugCachedVersion = null;
+  let bugFallbackMarkdown = '';
+
+  function bugEscape(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    })[c]);
+  }
+
+  async function bugFetchVersion() {
+    if (bugCachedVersion) return bugCachedVersion;
+    try {
+      const r = await fetch('/api/version', { cache: 'no-store' });
+      const d = await r.json();
+      bugCachedVersion = d && d.version ? String(d.version) : '';
+    } catch (_) {
+      bugCachedVersion = '';
+    }
+    return bugCachedVersion;
+  }
+
+  async function bugRenderMeta() {
+    const version = await bugFetchVersion();
+    const ua = (typeof navigator !== 'undefined' && navigator.userAgent) || '';
+    const sid = (typeof currentSession !== 'undefined' && currentSession && currentSession.id) || '';
+    if (!$bugMeta) return;
+    $bugMeta.innerHTML =
+      '<div><strong>CCC version:</strong> <code>' + bugEscape(version || '—') + '</code></div>' +
+      '<div><strong>Session:</strong> <code>' + bugEscape(sid || '—') + '</code></div>' +
+      '<div><strong>User agent:</strong> <code>' + bugEscape(ua || '—') + '</code></div>';
+  }
+
+  function bugResetState() {
+    if ($bugError) { $bugError.textContent = ''; $bugError.classList.remove('visible'); }
+    if ($bugSuccess) { $bugSuccess.innerHTML = ''; $bugSuccess.classList.remove('visible'); }
+    if ($bugFallback) { $bugFallback.textContent = ''; $bugFallback.classList.remove('visible'); }
+    if ($bugCopyBtn) $bugCopyBtn.style.display = 'none';
+    bugFallbackMarkdown = '';
+    if ($bugSubmitBtn) {
+      $bugSubmitBtn.disabled = false;
+      $bugSubmitBtn.textContent = 'Send report';
+    }
+    if ($bugCancelBtn) { $bugCancelBtn.disabled = false; $bugCancelBtn.textContent = 'Cancel'; }
+  }
+
+  function bugOpenModal() {
+    if (!$bugModal) return;
+    bugResetState();
+    if ($bugTitleInput) $bugTitleInput.value = '';
+    if ($bugDescInput) $bugDescInput.value = '';
+    bugRenderMeta();
+    $bugModal.classList.add('open');
+    setTimeout(() => { if ($bugTitleInput) $bugTitleInput.focus(); }, 0);
+  }
+  function bugCloseModal() {
+    if ($bugModal) $bugModal.classList.remove('open');
+  }
+
+  if ($bugLink) $bugLink.addEventListener('click', bugOpenModal);
+  if ($bugBackdrop) $bugBackdrop.addEventListener('click', bugCloseModal);
+  if ($bugCancelBtn) $bugCancelBtn.addEventListener('click', bugCloseModal);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && $bugModal && $bugModal.classList.contains('open')) {
+      bugCloseModal();
+    }
+  });
+
+  async function bugSubmit() {
+    if (!$bugTitleInput || !$bugDescInput) return;
+    const title = $bugTitleInput.value.trim();
+    const desc = $bugDescInput.value.trim();
+    bugResetState();
+    if (!title) {
+      if ($bugError) { $bugError.textContent = 'Please add a title.'; $bugError.classList.add('visible'); }
+      $bugTitleInput.focus();
+      return;
+    }
+    if (!desc) {
+      if ($bugError) { $bugError.textContent = 'Please describe the bug.'; $bugError.classList.add('visible'); }
+      $bugDescInput.focus();
+      return;
+    }
+    if ($bugSubmitBtn) { $bugSubmitBtn.disabled = true; $bugSubmitBtn.textContent = 'Sending…'; }
+    if ($bugCancelBtn) $bugCancelBtn.disabled = true;
+    const version = await bugFetchVersion();
+    const sid = (typeof currentSession !== 'undefined' && currentSession && currentSession.id) || '';
+    let data;
+    try {
+      const r = await fetch('/api/bug-report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title,
+          description: desc,
+          ccc_version: version || '',
+          user_agent: (navigator && navigator.userAgent) || '',
+          session_id: sid,
+        }),
+      });
+      data = await r.json().catch(() => ({}));
+    } catch (e) {
+      if ($bugError) {
+        $bugError.textContent = 'Network error: ' + (e && e.message ? e.message : 'unknown');
+        $bugError.classList.add('visible');
+      }
+      if ($bugSubmitBtn) { $bugSubmitBtn.disabled = false; $bugSubmitBtn.textContent = 'Send report'; }
+      if ($bugCancelBtn) $bugCancelBtn.disabled = false;
+      return;
+    }
+    if (data && data.ok && data.url) {
+      const safeUrl = bugEscape(data.url);
+      if ($bugSuccess) {
+        $bugSuccess.innerHTML = 'Thanks — issue filed: <a href="' + safeUrl + '" target="_blank" rel="noopener">' + safeUrl + '</a>';
+        $bugSuccess.classList.add('visible');
+      }
+      if ($bugSubmitBtn) { $bugSubmitBtn.disabled = true; $bugSubmitBtn.textContent = 'Sent'; }
+      if ($bugCancelBtn) { $bugCancelBtn.disabled = false; $bugCancelBtn.textContent = 'Close'; }
+      try { showOpToast('Bug report filed', 'success'); } catch (_) {}
+      return;
+    }
+    // Failure path. If the server returned `markdown` we offer a copy-
+    // to-clipboard fallback so the user can still file the issue manually.
+    const errMsg = (data && data.error) || 'Failed to submit bug report.';
+    if ($bugError) {
+      let msg = errMsg;
+      if (data && data.repo_url) {
+        msg += '\n\nFile manually at: ' + data.repo_url;
+      }
+      $bugError.textContent = msg;
+      $bugError.classList.add('visible');
+    }
+    if (data && data.markdown) {
+      bugFallbackMarkdown = String(data.markdown);
+      if ($bugFallback) {
+        $bugFallback.textContent = bugFallbackMarkdown;
+        $bugFallback.classList.add('visible');
+      }
+      if ($bugCopyBtn) $bugCopyBtn.style.display = 'inline-block';
+    }
+    if ($bugSubmitBtn) { $bugSubmitBtn.disabled = false; $bugSubmitBtn.textContent = 'Try again'; }
+    if ($bugCancelBtn) $bugCancelBtn.disabled = false;
+  }
+
+  if ($bugSubmitBtn) $bugSubmitBtn.addEventListener('click', bugSubmit);
+  if ($bugCopyBtn) $bugCopyBtn.addEventListener('click', async () => {
+    const md = bugFallbackMarkdown;
+    if (!md) return;
+    try {
+      await navigator.clipboard.writeText(md);
+      if ($bugCopyBtn) { $bugCopyBtn.textContent = 'Copied'; setTimeout(() => { if ($bugCopyBtn) $bugCopyBtn.textContent = 'Copy markdown'; }, 1500); }
+    } catch (_) {
+      try { showOpToast('Copy failed — select the text and copy manually', 'error'); } catch (__) {}
+    }
+  });
 
   // If we just finished restarting after a self-update, briefly acknowledge.
   try {


### PR DESCRIPTION
## Summary

Adds an in-app **Report a bug** flow so users can file issues against
`amirfish1/claude-command-center` without leaving CCC. Pattern adapted
from BookYourMat's existing widget, simplified for a localhost stdlib
server.

- New topbar link **Report a bug** (right of the version pill / setup
  banner) opens a modal with title + description fields.
- Modal auto-attaches a context block — CCC version (from
  `/api/version`), browser user-agent, and `currentSession.id` if a
  session is selected.
- New endpoint `POST /api/bug-report` shells out to
  `gh issue create -R amirfish1/claude-command-center --label bug`
  and returns the new issue URL.
- If `gh` is missing or `gh` exits non-zero, the server returns the
  rendered issue markdown and the client offers a **Copy markdown**
  button + a link to the manual issue page.

## What was taken from BYM

- The basic shape: modal + auto-context + server endpoint + GitHub
  issue creation.
- The fallback-markdown idea (BYM rendered email + GitHub markdown in
  the same handler) — here it doubles as the clipboard fallback when
  `gh` is unavailable.

## What was dropped

- All studio-specific fields (client name, appointment time, group
  type) — irrelevant outside scheduling.
- Email fan-out + Supabase storage upload — CCC is local-only with no
  external integrations beyond `gh`.
- `html2canvas` auto-screenshots + tap-tracking — would require a
  CDN script tag in the otherwise dependency-free single-file app.
  Skipped this round; can revisit.
- Staff/portal auth + audit-log fetch — CCC is single-user localhost.

## Manual test plan

- [ ] Click "Report a bug" in the topbar → modal opens with empty
      title/description, context block populated with CCC version,
      browser UA, and either a session id or `—`.
- [ ] Submit empty title → inline error, no network request fired.
- [ ] Submit empty description → inline error.
- [ ] Submit with valid fields and `gh` authed → toast + success
      message with a link to the new issue. Verify the issue exists in
      `amirfish1/claude-command-center` with the `bug` label and the
      auto-attached context table.
- [ ] Temporarily unset PATH so `gh` isn't found, submit → inline
      error message + the rendered markdown shown below + **Copy
      markdown** button. Click copy → clipboard contains the markdown.
- [ ] Esc / backdrop click / Cancel button closes the modal.

## API

New: `POST /api/bug-report`
- Request: `{title, description, ccc_version?, user_agent?, session_id?}`
- Success: `{ok: true, url, number}`
- Failure: `{ok: false, error, markdown?, repo_url?}`