### PR TITLE
feat(bug-report): area-screenshot capture + upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Screenshots in the bug-report modal — an "Add screenshot" button opens
+  the macOS area-selector (`screencapture -i`) so the user draws a
+  rectangle over exactly what they want to share. The preview renders in
+  the modal with Retake / Remove controls. On submit the image is committed
+  to a dedicated `bug-screenshots` branch of `amirfish1/claude-command-center`
+  and embedded inline in the issue body via `raw.githubusercontent.com`. If
+  the push fails (typical for OSS users without write access), the image is
+  saved to `~/.claude/command-center/bug-screenshots/`, Finder pops to it,
+  and the issue body carries a drag-drop instruction so the user can attach
+  it manually. New endpoints: `POST /api/bug-report/capture`,
+  `POST /api/bug-report/reveal`. `POST /api/bug-report` now accepts an
+  optional `screenshot_b64` field.
+
 ## [0.1.3] - 2026-04-24
 
 ### Added

--- a/server.py
+++ b/server.py
@@ -15,14 +15,17 @@ Usage:
 __version__ = "0.1.3"
 
 import ast
+import base64
 import http.server
 import json
 import os
 import platform
 import re
+import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import urllib.parse
@@ -397,16 +400,50 @@ def _self_update():
 # available we return the rendered markdown so the UI can offer a
 # copy-to-clipboard fallback for manual filing.
 _BUG_REPORT_REPO = "amirfish1/claude-command-center"
+# Screenshot support (macOS only): the modal can capture an area screenshot
+# via `screencapture -i`, which is then committed to a dedicated public
+# branch (`bug-screenshots`) of this repo so the issue body can render the
+# image inline via raw.githubusercontent.com. If the push fails (random OSS
+# user without write access) we keep the local copy and tell the user to
+# drag-drop manually. The local save ALWAYS happens first so the image is
+# never lost regardless of upload outcome.
+_BUG_SCREENSHOT_DIR = Path.home() / ".claude" / "command-center" / "bug-screenshots"
+_BUG_SCREENSHOT_WT = Path.home() / ".claude" / "command-center" / "bug-screenshots-wt"
+_BUG_SCREENSHOT_BRANCH = "bug-screenshots"
 
 
-def _build_bug_report_body(description, ccc_version, user_agent, session_id):
+def _build_bug_report_body(description, ccc_version, user_agent, session_id,
+                           screenshot_url=None, screenshot_local_path=None):
     """Render the GitHub issue body (markdown). Pure — no I/O — so it's
-    cheap to also return on the failure path for clipboard fallback."""
+    cheap to also return on the failure path for clipboard fallback.
+
+    Screenshot rendering: if `screenshot_url` is given we embed it as an
+    inline image (the happy path — image was pushed to the bug-screenshots
+    branch). Otherwise if `screenshot_local_path` is given we surface the
+    local path with a drag-drop instruction so the user can manually
+    attach it to the issue after it's filed."""
     lines = [
         "## Description",
         "",
         description.strip(),
         "",
+    ]
+    if screenshot_url:
+        lines += [
+            "## Screenshot",
+            "",
+            f"![screenshot]({screenshot_url})",
+            "",
+        ]
+    elif screenshot_local_path:
+        lines += [
+            "## Screenshot",
+            "",
+            f"📎 Saved locally at `{screenshot_local_path}`. After this issue "
+            "opens, drag the file into a comment to attach it.",
+            "",
+        ]
+    lines += [
         "## Context",
         "",
         "| Field | Value |",
@@ -420,15 +457,256 @@ def _build_bug_report_body(description, ccc_version, user_agent, session_id):
     return "\n".join(lines)
 
 
+def _capture_screenshot_native(timeout=120):
+    """Trigger the macOS area-screenshot picker (`screencapture -i`) and
+    return the resulting PNG as base64. Blocks until the user finishes
+    drawing the rectangle, presses Esc to cancel, or `timeout` elapses.
+
+    Returns one of:
+      {ok: True,  image_b64: "...", mime: "image/png", path: "/tmp/..."}
+      {ok: False, cancelled: True}                  — user pressed Esc
+      {ok: False, error: "..."}                     — non-mac, timeout, etc.
+
+    macOS-only: `screencapture` is a shipped system tool. On other OSes we
+    return an explanatory error so the UI can hide / explain the feature.
+    """
+    if platform.system() != "Darwin":
+        return {"ok": False, "error": "area screenshots are macOS-only today"}
+    if not _which("screencapture"):
+        return {"ok": False, "error": "`screencapture` not found on PATH"}
+    # NamedTemporaryFile(delete=False) so screencapture (a separate process)
+    # can write to the path; we reap it ourselves once we've base64-encoded.
+    tmp = tempfile.NamedTemporaryFile(prefix="ccc-bug-", suffix=".png", delete=False)
+    tmp_path = tmp.name
+    tmp.close()
+    try:
+        # `-i` is interactive: shows the crosshair / area-selector overlay.
+        # `-x` suppresses the camera-shutter sound so this isn't disruptive
+        # in a quiet office. The user draws an area; on Esc the file is left
+        # zero-bytes and screencapture exits 0.
+        try:
+            proc = subprocess.run(
+                ["screencapture", "-i", "-x", tmp_path],
+                capture_output=True, text=True, timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return {"ok": False, "error": f"screencapture timed out after {timeout}s"}
+        if proc.returncode != 0:
+            err = (proc.stderr or proc.stdout or "").strip()[:200]
+            return {"ok": False, "error": err or f"screencapture exited {proc.returncode}"}
+        try:
+            data = Path(tmp_path).read_bytes()
+        except OSError as e:
+            return {"ok": False, "error": f"could not read capture: {e}"}
+        # Esc / cancel leaves a zero-byte file behind. Treat as cancellation.
+        if not data:
+            return {"ok": False, "cancelled": True}
+        return {
+            "ok": True,
+            "image_b64": base64.b64encode(data).decode("ascii"),
+            "mime": "image/png",
+            "path": tmp_path,
+            "bytes": len(data),
+        }
+    finally:
+        # The client got the bytes inline; the temp file is no longer
+        # needed. Best-effort cleanup so /tmp doesn't fill up over time.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
+def _save_screenshot_locally(image_b64):
+    """Decode `image_b64` and write to ~/.claude/command-center/bug-screenshots/.
+    Returns the absolute path on success, or raises ValueError on bad input.
+    Called on the bug-report submission path BEFORE the upload attempt so
+    the screenshot survives even if everything else fails."""
+    try:
+        raw = base64.b64decode(image_b64, validate=True)
+    except (ValueError, TypeError) as e:
+        raise ValueError(f"invalid base64: {e}") from e
+    if not raw:
+        raise ValueError("empty screenshot")
+    _BUG_SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    # Filename: timestamp + short random suffix so back-to-back submissions
+    # in the same second don't collide.
+    fname = f"bug-{datetime.now().strftime('%Y%m%d-%H%M%S')}-{os.urandom(3).hex()}.png"
+    out = _BUG_SCREENSHOT_DIR / fname
+    out.write_bytes(raw)
+    return str(out)
+
+
+def _origin_owner_repo():
+    """Return (owner, repo) parsed from the install dir's `origin` remote, or
+    None if the dir isn't a clone or the URL doesn't look like GitHub.
+    Used to build the raw.githubusercontent.com URL for embedded screenshots
+    AND to derive the push URL for the bug-screenshots branch."""
+    rc, out, _ = _git(["remote", "get-url", "origin"], _install_dir())
+    if rc != 0:
+        return None
+    url = out.strip()
+    # Match git@github.com:owner/repo(.git) and https://github.com/owner/repo(.git).
+    m = re.match(r"^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$", url)
+    if not m:
+        m = re.match(r"^https?://github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$", url)
+    if not m:
+        return None
+    return (m.group(1), m.group(2))
+
+
+def _push_screenshot_to_branch(local_path, commit_subject):
+    """Copy `local_path` into the bug-screenshots scratch worktree, commit,
+    and push. Returns one of:
+      {ok: True,  raw_url: "https://raw.githubusercontent.com/.../<file>"}
+      {ok: False, error: "..."}
+
+    The scratch worktree at ~/.claude/command-center/bug-screenshots-wt/
+    is reused across runs. On first run the `bug-screenshots` branch
+    doesn't exist on origin so we create it as an orphan (no parent
+    commits — keeps it clean of main's history)."""
+    install = _install_dir()
+    rc, origin_url, err = _git(["remote", "get-url", "origin"], install)
+    if rc != 0:
+        return {"ok": False, "error": f"no origin remote: {err or 'rc={}'.format(rc)}"}
+    origin_url = origin_url.strip()
+    owner_repo = _origin_owner_repo()
+    if not owner_repo:
+        return {"ok": False, "error": f"origin URL not recognised as GitHub: {origin_url}"}
+    owner, repo = owner_repo
+
+    wt = _BUG_SCREENSHOT_WT
+    # Always rebuild the scratch dir if it isn't a healthy git clone — this
+    # keeps the logic dead-simple and avoids subtle stuck-state bugs (e.g.
+    # half-applied orphan switch from a prior crashed run). The cost is one
+    # extra `git init` + fetch per submission, which is negligible.
+    if not (wt / ".git").is_dir():
+        shutil.rmtree(wt, ignore_errors=True)
+        wt.mkdir(parents=True, exist_ok=True)
+        rc, _, err = _git(["init", "--quiet", "-b", "main"], wt)
+        if rc != 0:
+            # Older git without -b flag — retry without it.
+            shutil.rmtree(wt, ignore_errors=True)
+            wt.mkdir(parents=True, exist_ok=True)
+            rc, _, err = _git(["init", "--quiet"], wt)
+            if rc != 0:
+                return {"ok": False, "error": f"git init failed: {err}"}
+        rc, _, err = _git(["remote", "add", "origin", origin_url], wt)
+        if rc != 0:
+            return {"ok": False, "error": f"git remote add failed: {err}"}
+
+    # Try to fetch the existing bug-screenshots branch. If origin doesn't
+    # have it yet (first push ever), we'll create it as an orphan below.
+    rc, _, fetch_err = _git(
+        ["fetch", "origin", _BUG_SCREENSHOT_BRANCH, "--quiet"], wt, timeout=30,
+    )
+    branch_on_origin = (rc == 0)
+
+    if branch_on_origin:
+        # Hard-reset to remote so we don't accumulate junk commits locally
+        # when the user submits multiple bug reports.
+        rc, _, err = _git(
+            ["checkout", "-B", _BUG_SCREENSHOT_BRANCH,
+             f"origin/{_BUG_SCREENSHOT_BRANCH}", "--quiet"], wt,
+        )
+        if rc != 0:
+            return {"ok": False, "error": f"checkout bug-screenshots failed: {err}"}
+    else:
+        # First-ever push: create the branch as an orphan so its history is
+        # independent from main. Wipe any tracked files left over from a
+        # previous half-baked run (`git switch --orphan` doesn't touch the
+        # working tree).
+        rc, _, err = _git(["switch", "--orphan", _BUG_SCREENSHOT_BRANCH], wt)
+        if rc != 0:
+            # `git switch` requires git 2.23+. On ancient git fall back to
+            # the symbolic-ref + rm-cached dance.
+            rc, _, err = _git(
+                ["symbolic-ref", "HEAD", f"refs/heads/{_BUG_SCREENSHOT_BRANCH}"], wt,
+            )
+            if rc != 0:
+                return {"ok": False, "error": f"orphan branch create failed: {err}"}
+            # Drop any stale index entries so the orphan starts empty.
+            _git(["rm", "-rf", "--cached", "--quiet", "."], wt)
+        # Clean the working tree of any leftover files (other than .git).
+        for entry in wt.iterdir():
+            if entry.name == ".git":
+                continue
+            try:
+                if entry.is_dir():
+                    shutil.rmtree(entry)
+                else:
+                    entry.unlink()
+            except OSError:
+                pass
+
+    # Configure local user/email for the commit so this works on a fresh
+    # box without ~/.gitconfig user.email set. Safe scope: --local only
+    # touches this scratch dir's .git/config, never global config.
+    _git(["config", "--local", "user.name", "Claude Command Center"], wt)
+    _git(["config", "--local", "user.email", "ccc-bug-report@localhost"], wt)
+
+    # Copy the screenshot in under its basename and stage it explicitly —
+    # never `git add -A`, both because of the multi-agent rule and because
+    # we want to be defensive about anything else lingering in the WT.
+    fname = Path(local_path).name
+    dest = wt / fname
+    try:
+        shutil.copy2(local_path, dest)
+    except OSError as e:
+        return {"ok": False, "error": f"copy failed: {e}"}
+
+    rc, _, err = _git(["add", fname], wt)
+    if rc != 0:
+        return {"ok": False, "error": f"git add failed: {err}"}
+
+    # Cap the commit subject so a pathological title doesn't push the
+    # commit message over GitHub's display limits.
+    subject = (commit_subject or "screenshot").strip()
+    if len(subject) > 100:
+        subject = subject[:100].rstrip() + "…"
+    rc, _, err = _git(
+        ["commit", "-m", f"add screenshot: {subject}", "--quiet"], wt,
+    )
+    if rc != 0:
+        return {"ok": False, "error": f"git commit failed: {err}"}
+
+    rc, _, err = _git(
+        ["push", "-u", "origin", _BUG_SCREENSHOT_BRANCH, "--quiet"], wt, timeout=30,
+    )
+    if rc != 0:
+        return {"ok": False, "error": f"git push failed: {err[:300] if err else 'rc={}'.format(rc)}"}
+
+    raw_url = (
+        f"https://raw.githubusercontent.com/{owner}/{repo}/"
+        f"{_BUG_SCREENSHOT_BRANCH}/{urllib.parse.quote(fname)}"
+    )
+    return {"ok": True, "raw_url": raw_url, "filename": fname}
+
+
+def _bug_log(msg):
+    """Single-line stderr logger for the bug-report flow. Useful when the
+    push succeeds silently but the user-side render looks off — easier to
+    grep `[bug-report]` in the server console than to hunt timestamps."""
+    print(f"[bug-report] {msg}", file=sys.stderr, flush=True)
+
+
 def _create_bug_report_issue(payload):
     """Validate the payload, build a GitHub issue, file it via `gh`.
 
     Returns one of:
-      {ok: True,  url: "https://github.com/.../issues/N", number: N}
+      {ok: True,  url: ".../issues/N", number: N,
+       screenshot_needs_manual?: True, screenshot_path?: "<abs>"}
       {ok: False, error: "...",  markdown: "..."}   # gh missing / failed
       {ok: False, error: "..."}                     # validation failure
     The `markdown` key on the failure path lets the client offer a
     copy-to-clipboard fallback so the user can file it manually.
+
+    Optional `screenshot_b64` field: PNG bytes (base64, no data: prefix).
+    Always saved locally first; then we try to push to the bug-screenshots
+    branch for inline rendering. On push failure the issue body falls back
+    to the local path + drag-drop instructions, and the response carries
+    `screenshot_needs_manual=true` so the client can `open -R` the file
+    and surface the issue URL for manual attachment.
     """
     title = (payload.get("title") or "").strip()
     description = (payload.get("description") or "").strip()
@@ -445,7 +723,38 @@ def _create_bug_report_issue(payload):
     user_agent = (payload.get("user_agent") or "").strip()
     session_id = (payload.get("session_id") or "").strip()
 
-    body = _build_bug_report_body(description, ccc_version, user_agent, session_id)
+    # ── Screenshot pre-flight ──
+    # Save first (always), then try to push, then build the body. The
+    # `screenshot_*` locals stay None when no image was supplied so the
+    # body builder skips the screenshot section entirely.
+    screenshot_b64 = (payload.get("screenshot_b64") or "").strip()
+    screenshot_local_path = None
+    screenshot_url = None
+    screenshot_needs_manual = False
+    if screenshot_b64:
+        try:
+            screenshot_local_path = _save_screenshot_locally(screenshot_b64)
+            _bug_log(f"screenshot saved locally at {screenshot_local_path}")
+        except ValueError as e:
+            # Bad base64 isn't fatal — we just skip the screenshot section
+            # so the bug report itself still gets filed. Log loudly so the
+            # client-side bug is findable.
+            _bug_log(f"screenshot decode failed, skipping: {e}")
+            screenshot_local_path = None
+        if screenshot_local_path:
+            push = _push_screenshot_to_branch(screenshot_local_path, title)
+            if push.get("ok"):
+                screenshot_url = push["raw_url"]
+                _bug_log(f"screenshot pushed: {screenshot_url}")
+            else:
+                screenshot_needs_manual = True
+                _bug_log(f"screenshot push failed, using local fallback: {push.get('error')}")
+
+    body = _build_bug_report_body(
+        description, ccc_version, user_agent, session_id,
+        screenshot_url=screenshot_url,
+        screenshot_local_path=screenshot_local_path if screenshot_needs_manual else None,
+    )
     fallback_md = f"## {title}\n\n{body}"
 
     if not _which("gh"):
@@ -454,6 +763,7 @@ def _create_bug_report_issue(payload):
             "error": "gh CLI not found on PATH — copy the markdown and file the issue manually.",
             "markdown": fallback_md,
             "repo_url": f"https://github.com/{_BUG_REPORT_REPO}/issues/new",
+            "screenshot_path": screenshot_local_path,
         }
 
     try:
@@ -471,9 +781,11 @@ def _create_bug_report_issue(payload):
             capture_output=True, text=True, timeout=20,
         )
     except subprocess.TimeoutExpired:
-        return {"ok": False, "error": "gh issue create timed out", "markdown": fallback_md}
+        return {"ok": False, "error": "gh issue create timed out", "markdown": fallback_md,
+                "screenshot_path": screenshot_local_path}
     except (OSError, subprocess.SubprocessError) as e:
-        return {"ok": False, "error": f"gh failed to launch: {e}", "markdown": fallback_md}
+        return {"ok": False, "error": f"gh failed to launch: {e}", "markdown": fallback_md,
+                "screenshot_path": screenshot_local_path}
 
     if proc.returncode != 0:
         err = (proc.stderr or proc.stdout or "").strip()[:400]
@@ -482,6 +794,7 @@ def _create_bug_report_issue(payload):
             "error": err or f"gh issue create exited {proc.returncode}",
             "markdown": fallback_md,
             "repo_url": f"https://github.com/{_BUG_REPORT_REPO}/issues/new",
+            "screenshot_path": screenshot_local_path,
         }
 
     url = (proc.stdout or "").strip().splitlines()[-1] if proc.stdout else ""
@@ -489,7 +802,35 @@ def _create_bug_report_issue(payload):
     m = re.search(r"/issues/(\d+)", url)
     if m:
         number = int(m.group(1))
-    return {"ok": True, "url": url, "number": number}
+    result = {"ok": True, "url": url, "number": number}
+    if screenshot_needs_manual and screenshot_local_path:
+        result["screenshot_needs_manual"] = True
+        result["screenshot_path"] = screenshot_local_path
+    return result
+
+
+def _reveal_bug_screenshot(path_str):
+    """Reveal `path_str` in Finder via `open -R`. Sandbox-clamped to the
+    bug-screenshots dir so this can't be abused to reveal arbitrary files.
+    Used by the manual-attach fallback after the issue is filed."""
+    if platform.system() != "Darwin":
+        return {"ok": False, "error": "macOS-only"}
+    if not path_str:
+        return {"ok": False, "error": "missing path"}
+    try:
+        rp = Path(path_str).expanduser().resolve(strict=False)
+        root = _BUG_SCREENSHOT_DIR.resolve()
+    except OSError as e:
+        return {"ok": False, "error": str(e)}
+    if not (str(rp).startswith(str(root) + os.sep) or rp == root):
+        return {"ok": False, "error": "path outside bug-screenshots sandbox"}
+    if not rp.exists():
+        return {"ok": False, "error": "file not found", "path": str(rp)}
+    try:
+        subprocess.Popen(["open", "-R", str(rp)])
+        return {"ok": True, "path": str(rp)}
+    except OSError as e:
+        return {"ok": False, "error": str(e)}
 
 
 def _schedule_restart(delay=0.5):
@@ -5892,6 +6233,28 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
                 self.send_json(result, 400)
             else:
                 self.send_json(result)
+            return
+        if path == "/api/bug-report/capture":
+            # Trigger the macOS area-screenshot picker. Blocks the request
+            # thread until the user finishes drawing or hits Esc — fine
+            # because each request runs on its own thread under
+            # ThreadingHTTPServer. 120s timeout so an idle dialog can't
+            # tie up a server thread forever.
+            result = _capture_screenshot_native()
+            self.send_json(result)
+            return
+        if path == "/api/bug-report/reveal":
+            # Reveal a previously-saved bug screenshot in Finder so the
+            # user can drag-drop it into a GitHub issue comment. Sandbox-
+            # clamped to ~/.claude/command-center/bug-screenshots/ inside
+            # the helper so this can't be abused as a generic file-reveal.
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length) if length > 0 else b""
+            try:
+                payload = json.loads(body) if body else {}
+            except json.JSONDecodeError:
+                payload = {}
+            self.send_json(_reveal_bug_screenshot((payload.get("path") or "").strip()))
             return
         if path == "/api/fs/pick-folder":
             # Open the OS-native folder chooser and return the picked absolute

--- a/static/index.html
+++ b/static/index.html
@@ -1272,6 +1272,47 @@
     font-family: 'SF Mono',SFMono-Regular,Consolas,monospace;
   }
   .bug-fallback.visible { display: block; }
+  .bug-shot-row {
+    display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  }
+  .bug-shot-btn {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 5px 10px; border-radius: 6px;
+    background: var(--bg); color: var(--text);
+    border: 1px solid var(--border);
+    font-family: inherit; font-size: 12px; cursor: pointer;
+    transition: background 0.12s ease-out, border-color 0.12s ease-out;
+  }
+  .bug-shot-btn:hover { background: rgba(255,255,255,0.04); border-color: var(--accent); }
+  .bug-shot-btn:disabled { opacity: 0.6; cursor: progress; }
+  .bug-shot-btn .bug-shot-ico {
+    display: inline-block; width: 12px; height: 12px;
+    border: 1.5px solid currentColor; border-radius: 2px;
+    position: relative;
+  }
+  .bug-shot-btn .bug-shot-ico::after {
+    content: ""; position: absolute;
+    top: 1.5px; left: 3px; right: 3px; height: 1.5px;
+    background: currentColor; border-radius: 1px;
+  }
+  .bug-shot-help {
+    font-size: 10.5px; color: var(--text-muted);
+    margin-top: 6px; line-height: 1.45;
+  }
+  .bug-shot-preview {
+    margin-top: 8px; display: none;
+    border: 1px solid var(--border); border-radius: 6px;
+    padding: 8px; background: var(--bg);
+  }
+  .bug-shot-preview.visible { display: block; }
+  .bug-shot-preview img {
+    display: block; max-width: 100%; max-height: 200px;
+    border-radius: 4px; margin: 0 auto 8px;
+    background: rgba(0,0,0,0.2);
+  }
+  .bug-shot-preview-actions {
+    display: flex; justify-content: flex-end; gap: 6px;
+  }
 
   /* Backlog column — no longer sticky, scrolls with the rest */
   /* Reuse kanban column/card styles in split mode */
@@ -2443,6 +2484,27 @@
         <label class="bug-label" for="bugReportDescInput">Description</label>
         <textarea id="bugReportDescInput" class="bug-input bug-textarea"
                   placeholder="What did you see? What did you expect? Steps to reproduce…"></textarea>
+      </div>
+      <div>
+        <label class="bug-label">Screenshot (optional)</label>
+        <div class="bug-shot-row">
+          <button type="button" class="bug-shot-btn" id="bugReportShotBtn">
+            <span class="bug-shot-ico" aria-hidden="true"></span>
+            <span id="bugReportShotBtnLabel">Add screenshot</span>
+          </button>
+        </div>
+        <div class="bug-shot-help">
+          Opens the macOS area-selector — draw a rectangle over what you want to share.
+          Screenshots are published to a public branch of the CCC repo, so include
+          only what you're OK making public.
+        </div>
+        <div class="bug-shot-preview" id="bugReportShotPreview">
+          <img id="bugReportShotImg" alt="Screenshot preview" />
+          <div class="bug-shot-preview-actions">
+            <button type="button" class="bug-shot-btn" id="bugReportShotRetakeBtn">Retake</button>
+            <button type="button" class="bug-shot-btn" id="bugReportShotRemoveBtn">Remove</button>
+          </div>
+        </div>
       </div>
       <div>
         <label class="bug-label">Auto-attached context</label>
@@ -8116,8 +8178,15 @@
   const $bugCancelBtn = document.getElementById('bugReportCancelBtn');
   const $bugSubmitBtn = document.getElementById('bugReportSubmitBtn');
   const $bugCopyBtn = document.getElementById('bugReportCopyBtn');
+  const $bugShotBtn = document.getElementById('bugReportShotBtn');
+  const $bugShotBtnLabel = document.getElementById('bugReportShotBtnLabel');
+  const $bugShotPreview = document.getElementById('bugReportShotPreview');
+  const $bugShotImg = document.getElementById('bugReportShotImg');
+  const $bugShotRetakeBtn = document.getElementById('bugReportShotRetakeBtn');
+  const $bugShotRemoveBtn = document.getElementById('bugReportShotRemoveBtn');
   let bugCachedVersion = null;
   let bugFallbackMarkdown = '';
+  let bugShotB64 = '';  // raw base64 PNG (no data: prefix), '' when no screenshot
 
   function bugEscape(s) {
     return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => ({
@@ -8148,18 +8217,72 @@
       '<div><strong>User agent:</strong> <code>' + bugEscape(ua || '—') + '</code></div>';
   }
 
+  function bugClearShot() {
+    bugShotB64 = '';
+    if ($bugShotImg) $bugShotImg.src = '';
+    if ($bugShotPreview) $bugShotPreview.classList.remove('visible');
+    if ($bugShotBtnLabel) $bugShotBtnLabel.textContent = 'Add screenshot';
+    if ($bugShotBtn) $bugShotBtn.disabled = false;
+  }
+
   function bugResetState() {
     if ($bugError) { $bugError.textContent = ''; $bugError.classList.remove('visible'); }
     if ($bugSuccess) { $bugSuccess.innerHTML = ''; $bugSuccess.classList.remove('visible'); }
     if ($bugFallback) { $bugFallback.textContent = ''; $bugFallback.classList.remove('visible'); }
     if ($bugCopyBtn) $bugCopyBtn.style.display = 'none';
     bugFallbackMarkdown = '';
+    bugClearShot();
     if ($bugSubmitBtn) {
       $bugSubmitBtn.disabled = false;
       $bugSubmitBtn.textContent = 'Send report';
     }
     if ($bugCancelBtn) { $bugCancelBtn.disabled = false; $bugCancelBtn.textContent = 'Cancel'; }
   }
+
+  async function bugCaptureScreenshot() {
+    // Hands off to the server, which shells out to `screencapture -i` and
+    // blocks until the user finishes drawing or hits Esc. The button stays
+    // in a "spinner" state for the entire window so it's clear something
+    // is waiting on the user.
+    if (!$bugShotBtn) return;
+    if ($bugError) { $bugError.textContent = ''; $bugError.classList.remove('visible'); }
+    $bugShotBtn.disabled = true;
+    if ($bugShotBtnLabel) $bugShotBtnLabel.textContent = 'Drawing…';
+    let data;
+    try {
+      const r = await fetch('/api/bug-report/capture', { method: 'POST' });
+      data = await r.json().catch(() => ({}));
+    } catch (e) {
+      if ($bugError) {
+        $bugError.textContent = 'Capture failed: ' + (e && e.message ? e.message : 'unknown');
+        $bugError.classList.add('visible');
+      }
+      bugClearShot();
+      return;
+    }
+    if (data && data.cancelled) {
+      // User pressed Esc — they bailed on purpose, no error noise.
+      bugClearShot();
+      return;
+    }
+    if (!data || !data.ok || !data.image_b64) {
+      if ($bugError) {
+        $bugError.textContent = (data && data.error) || 'Could not capture screenshot.';
+        $bugError.classList.add('visible');
+      }
+      bugClearShot();
+      return;
+    }
+    bugShotB64 = data.image_b64;
+    if ($bugShotImg) $bugShotImg.src = 'data:' + (data.mime || 'image/png') + ';base64,' + data.image_b64;
+    if ($bugShotPreview) $bugShotPreview.classList.add('visible');
+    if ($bugShotBtnLabel) $bugShotBtnLabel.textContent = 'Replace screenshot';
+    $bugShotBtn.disabled = false;
+  }
+
+  if ($bugShotBtn) $bugShotBtn.addEventListener('click', bugCaptureScreenshot);
+  if ($bugShotRetakeBtn) $bugShotRetakeBtn.addEventListener('click', bugCaptureScreenshot);
+  if ($bugShotRemoveBtn) $bugShotRemoveBtn.addEventListener('click', bugClearShot);
 
   function bugOpenModal() {
     if (!$bugModal) return;
@@ -8198,22 +8321,30 @@
       $bugDescInput.focus();
       return;
     }
-    if ($bugSubmitBtn) { $bugSubmitBtn.disabled = true; $bugSubmitBtn.textContent = 'Sending…'; }
+    if ($bugSubmitBtn) {
+      $bugSubmitBtn.disabled = true;
+      // Sending an image takes a couple of seconds (push to a public branch
+      // before gh issue create) — surface that explicitly so the user
+      // doesn't think the submit hung.
+      $bugSubmitBtn.textContent = bugShotB64 ? 'Sending (uploading screenshot)…' : 'Sending…';
+    }
     if ($bugCancelBtn) $bugCancelBtn.disabled = true;
     const version = await bugFetchVersion();
     const sid = (typeof currentSession !== 'undefined' && currentSession && currentSession.id) || '';
+    const payload = {
+      title,
+      description: desc,
+      ccc_version: version || '',
+      user_agent: (navigator && navigator.userAgent) || '',
+      session_id: sid,
+    };
+    if (bugShotB64) payload.screenshot_b64 = bugShotB64;
     let data;
     try {
       const r = await fetch('/api/bug-report', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          title,
-          description: desc,
-          ccc_version: version || '',
-          user_agent: (navigator && navigator.userAgent) || '',
-          session_id: sid,
-        }),
+        body: JSON.stringify(payload),
       });
       data = await r.json().catch(() => ({}));
     } catch (e) {
@@ -8227,8 +8358,30 @@
     }
     if (data && data.ok && data.url) {
       const safeUrl = bugEscape(data.url);
+      let html = 'Thanks — issue filed: <a href="' + safeUrl + '" target="_blank" rel="noopener">' + safeUrl + '</a>';
+      if (data.screenshot_needs_manual && data.screenshot_path) {
+        // Push to bug-screenshots branch failed (typical for OSS users
+        // without write access). Show the local path with a clear
+        // drag-drop instruction, AND fire-and-forget a /reveal so Finder
+        // pops to the file. The user finishes the attachment manually.
+        const safePath = bugEscape(data.screenshot_path);
+        html += '<div style="margin-top:8px;line-height:1.5;">'
+              + 'Screenshot upload failed — saved locally at '
+              + '<code style="font-family:\'SF Mono\',monospace;font-size:11px;">' + safePath + '</code>. '
+              + 'Drag this file into a comment on the issue to attach it. '
+              + 'Finder should be opening to it now.'
+              + '</div>';
+        try {
+          fetch('/api/bug-report/reveal', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ path: data.screenshot_path }),
+          });
+        } catch (_) { /* best effort */ }
+        try { window.open(data.url, '_blank', 'noopener'); } catch (_) {}
+      }
       if ($bugSuccess) {
-        $bugSuccess.innerHTML = 'Thanks — issue filed: <a href="' + safeUrl + '" target="_blank" rel="noopener">' + safeUrl + '</a>';
+        $bugSuccess.innerHTML = html;
         $bugSuccess.classList.add('visible');
       }
       if ($bugSubmitBtn) { $bugSubmitBtn.disabled = true; $bugSubmitBtn.textContent = 'Sent'; }


### PR DESCRIPTION
## Summary

Adds **screenshot support** to the in-app bug-report modal that shipped in v0.1.3.

- **Capture:** click *Add screenshot* → macOS area-selector (`screencapture -i`) → user draws a rectangle over whatever part of any screen they want to share. No full-window, no html2canvas — privacy by default.
- **Preview:** the cropped image renders inline in the modal with **Retake** / **Remove** controls so the user reviews exactly what they're about to publish before hitting Send.
- **Upload:** the PNG is committed to a dedicated `bug-screenshots` orphan branch of this repo (first push creates the branch) and the issue body embeds it via `raw.githubusercontent.com` so it renders inline on github.com.
- **Local-save first:** the image is written to `~/.claude/command-center/bug-screenshots/<ts>.png` *before* the push attempt — it's never lost regardless of upload outcome.
- **Push-fail fallback (OSS users without write access):** the issue body carries the local path with a drag-drop instruction, Finder opens to the file via a sandbox-clamped `open -R`, and the issue URL opens in a new tab so the user can finish the attachment manually.

## API surface

New endpoints (POST, gated by the existing same-origin check):

- `POST /api/bug-report/capture` — triggers `screencapture -i`, blocks on user input (120s timeout), returns `{ok, image_b64, mime, path}` or `{ok:false, cancelled:true}` on Esc.
- `POST /api/bug-report/reveal` — `open -R <path>`, clamped to `~/.claude/command-center/bug-screenshots/`.

`POST /api/bug-report` now accepts an optional `screenshot_b64` field (raw base64, no `data:` prefix). Existing callers that don't send it are unaffected — purely additive.

## Privacy

Captures are area-only and shown to the user before submit. The helper text in the modal calls out that *"Screenshots are published to a public branch of the CCC repo, so include only what you're OK making public."*

## Test plan

- [ ] Open the bug modal. Click **Add screenshot**. macOS area-selector appears. Draw a rectangle. Preview shows the cropped image. Press **Retake** — re-runs the capture. Press **Remove** — preview disappears, button reverts.
- [ ] Press Esc during capture — UI silently returns to the unchanged modal, no error noise.
- [ ] Submit a report with a screenshot. Verify on github.com that the issue body has `![screenshot](https://raw.githubusercontent.com/amirfish1/claude-command-center/bug-screenshots/<file>.png)` and the image renders inline. Confirm the `bug-screenshots` branch has a fresh commit with the file.
- [ ] **Simulate push fail** by temporarily breaking the install dir's `origin` (e.g. `git remote set-url origin git@github.com:nonexistent/repo.git` in the install dir, submit, then restore). Verify: the issue body has the local path with the drag-drop instruction, Finder opens to the saved PNG, the issue URL opens in a new tab, and the file under `~/.claude/command-center/bug-screenshots/` is intact.
- [ ] Submit a report **without** a screenshot. Existing behaviour unchanged — issue body has Description + Context only, no Screenshot section.
- [ ] `python3 -m unittest discover tests` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)