### PR TITLE
feat(ui): add Open in Claude Desktop button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `~/.claude/command-center/last-interactions.json`, and the kanban now sorts by
   `max(last_interacted, modified)` so a card you just typed into bubbles to the
   top instantly even before Claude responds.
+- **"Open in Claude Desktop" button** beside Jump/Launch in the
+  conversation toolbar (and the conversation-pane chrome). Resumes the
+  current session inside the Claude Desktop GUI app via the
+  `claude://resume?session=<uuid>` deep-link — the desktop app imports
+  the CLI session and navigates to it. macOS only for now (relies on
+  `open(1)`).
 
 ### Changed
 - **Renamed `Planning` column to `Icebox` and collapsed pre-tool live state into `Working`.**

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ writes sidecar state the UI uses for the kanban.
 - **Attach to existing sessions** — terminal `claude` processes show up
   automatically. Jump-to-terminal focuses them by TTY; rename/color the
   tab via Claude's own slash commands.
+- **Open in Claude Desktop** (macOS) — third destination button beside
+  Jump/Launch in the conversation toolbar; resumes the current CLI
+  session inside the Claude Desktop app via the `claude://resume` deep
+  link.
 - **Headless spawn with follow-up** — launch `claude -p` sessions from the
   dashboard and keep talking to them via an in-browser input bar (no
   terminal needed, stdin pipe stays open).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-command-center"
-version = "0.1.3"
+version = "0.2.0"
 description = "A local command center for Claude Code that doesn't care how your agents were launched."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.py
+++ b/server.py
@@ -12,7 +12,7 @@ Usage:
     CCC_WATCH_REPO=~/dev/foo ./run.sh
 """
 
-__version__ = "0.1.3"
+__version__ = "0.2.0"
 
 import ast
 import http.server
@@ -2160,6 +2160,43 @@ def _build_resume_command(session_id, cwd, cwd_exists):
             f"&& cd {q_cwd} && claude --resume {session_id}"
         )
     return f"cd {q_cwd} && claude --resume {session_id}"
+
+
+# UUID-format check — Claude Desktop's deep-link handler validates the
+# session ID against a UUID regex internally and silently drops anything
+# else. We pre-check so the UI gets a clear error instead of an opaque
+# "nothing happened".
+_SESSION_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def open_session_in_claude_desktop(session_id):
+    """Open the macOS Claude Desktop app and resume `session_id`.
+
+    Uses the registered `claude://resume?session=<uuid>` deep-link, which
+    the desktop app handles by importing the CLI session and navigating
+    to it. macOS only — relies on `open(1)`.
+
+    Returns {ok, error?, url?}.
+    """
+    if not session_id:
+        return {"ok": False, "error": "missing session_id"}
+    if not _SESSION_UUID_RE.match(session_id):
+        return {"ok": False, "error": "invalid session_id (expected UUID)"}
+    if sys.platform != "darwin":
+        return {"ok": False, "error": "Claude Desktop deep-link is macOS-only"}
+    url = f"claude://resume?session={session_id}"
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        log_path = LOG_DIR / f"desktop-{session_id[:8]}.log"
+        lf = open(log_path, "w")
+        subprocess.Popen(["open", url], stdout=lf, stderr=lf)
+    except (FileNotFoundError, OSError) as e:
+        print(f"open_session_in_claude_desktop: {e!r}", file=sys.stderr, flush=True)
+        return {"ok": False, "error": "could not launch Claude Desktop", "url": url}
+    return {"ok": True, "url": url}
 
 
 def launch_terminal_for_session(session_id, cwd=None, terminal_app=None):
@@ -7994,6 +8031,15 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
                 tty = status.get("tty") or ""
                 term_app = status.get("terminal_app") or ""
             self.send_json(focus_terminal_by_tty(tty, term_app))
+        elif path == "/api/open-in-desktop":
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length) if length > 0 else b""
+            try:
+                payload = json.loads(body) if body else {}
+            except json.JSONDecodeError:
+                payload = {}
+            sid = payload.get("session_id", "")
+            self.send_json(open_session_in_claude_desktop(sid))
         else:
             self.send_json({"error": "Not found"}, 404)
 

--- a/static/index.html
+++ b/static/index.html
@@ -234,6 +234,17 @@
   .toolbar .announce-btn-conv:hover { opacity: 0.9; }
   .toolbar .announce-btn-conv:active { transform: scale(0.97); }
   .toolbar .announce-btn-conv:disabled { opacity: 0.6; cursor: default; }
+  .toolbar .desktop-btn {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 5px 12px; border-radius: 6px; cursor: pointer;
+    background: rgba(57, 210, 192, 0.12); color: var(--cyan);
+    border: 1px solid rgba(57, 210, 192, 0.35);
+    font-size: 12px; font-weight: 600; font-family: inherit;
+    transition: background 0.15s, transform 0.1s;
+  }
+  .toolbar .desktop-btn:hover { background: rgba(57, 210, 192, 0.22); }
+  .toolbar .desktop-btn:active { transform: scale(0.97); }
+  .toolbar .desktop-btn.opening { opacity: 0.6; }
 
   .content {
     flex: 1; overflow-y: auto; padding: 16px 20px;
@@ -2271,8 +2282,8 @@
     /* Jump/Launch only affect the host's Terminal.app — useless when the UI is
        viewed from a remote/mobile context. Hide to avoid the "clicked, nothing
        happened" UX. */
-    #cpJumpBtn, #cpLaunchBtn,
-    #jumpBtnConv, #launchBtnConv,
+    #cpJumpBtn, #cpLaunchBtn, #cpDesktopBtn,
+    #jumpBtnConv, #launchBtnConv, #desktopBtnConv,
     .toolbar .resume-btn { display: none !important; }
 
     /* Kill iOS double-tap-to-click on cards (hover states triggered first tap) */
@@ -2691,6 +2702,10 @@
         <span class="jump-icon">&#43;</span>
         <span class="jump-label">Launch in terminal</span>
       </button>
+      <button class="desktop-btn" id="desktopBtnConv" style="display:none;" title="Resume this session in the Claude Desktop app">
+        <span class="jump-icon">&#9636;</span>
+        <span class="jump-label">Open in Claude Desktop</span>
+      </button>
       <span class="status" id="convStatus"></span>
       <div class="font-size-controls" style="margin-left:auto;">
         <button class="font-size-btn" id="fontMinus" title="Decrease font size">A-</button>
@@ -2741,6 +2756,7 @@
         <button class="mobile-back-btn" id="cpMobileBackBtn" title="Back to board">&#8592; Back</button>
         <button id="cpJumpBtn" style="display:none;" title="Jump to terminal"><span>&#8599;</span> Jump</button>
         <button id="cpLaunchBtn" style="display:none;" title="Launch in terminal"><span>&#43;</span> Launch</button>
+        <button id="cpDesktopBtn" style="display:none;" title="Open in Claude Desktop"><span>&#9636;</span> Desktop</button>
         <button id="cpKillBtn" style="display:none;" title="Kill agent">Kill</button>
         <div style="display:flex;gap:4px;margin-left:auto;">
           <button id="cpFontMinus" title="Decrease font size">A-</button>
@@ -3086,6 +3102,7 @@
 
   const $jumpBtnConv = document.getElementById('jumpBtnConv');
   const $launchBtnConv = document.getElementById('launchBtnConv');
+  const $desktopBtnConv = document.getElementById('desktopBtnConv');
   const $convToolbar = document.getElementById('convToolbar');
   const $announceBtnConv = document.getElementById('announceBtnConv');
   const $pkoodKillBtn = document.getElementById('pkoodKillBtn');
@@ -3127,9 +3144,14 @@
     if (activeTab === 'sessions') return [$launchBtnConv];
     return [];
   }
+  function desktopButtonsForActiveTab() {
+    if (activeTab === 'sessions') return [$desktopBtnConv];
+    return [];
+  }
   function allResumeButtons() { return []; }
   function allJumpButtons() { return [$jumpBtnConv].filter(Boolean); }
   function allLaunchButtons() { return [$launchBtnConv].filter(Boolean); }
+  function allDesktopButtons() { return [$desktopBtnConv].filter(Boolean); }
 
   // The Resume-in-CLI button used to live in convToolbar; it was removed
   // because every session row already exposes the same command via its
@@ -3184,6 +3206,7 @@
     const sid = currentSession.id;
     const canJump = live && liveStatus.tty && liveStatus.terminalApp;
     const canLaunch = !!sid && !canJump;  // only show Launch when Jump isn't available
+    const canOpenDesktop = !!sid;  // always available when a session is selected
 
     // Jump buttons
     const activeJump = jumpButtonsForActiveTab();
@@ -3212,6 +3235,22 @@
         btn.style.display = 'inline-flex';
         btn.title = 'Open a new Terminal window and run claude --resume';
         btn.querySelector('.jump-label').textContent = 'Launch in terminal';
+      } else {
+        btn.style.display = 'none';
+      }
+    }
+
+    // Desktop buttons (always-visible third destination)
+    const activeDesktop = desktopButtonsForActiveTab();
+    for (const btn of allDesktopButtons()) {
+      if (!activeDesktop.includes(btn)) btn.style.display = 'none';
+    }
+    for (const btn of activeDesktop) {
+      if (!btn) continue;
+      if (canOpenDesktop) {
+        btn.style.display = 'inline-flex';
+        btn.title = 'Resume this session in the Claude Desktop app';
+        btn.querySelector('.jump-label').textContent = 'Open in Claude Desktop';
       } else {
         btn.style.display = 'none';
       }
@@ -3449,6 +3488,39 @@
     }
   }
 
+  async function openInClaudeDesktop(ev) {
+    const btn = ev && ev.currentTarget;
+    if (!btn || !currentSession.id) return;
+    const origLabel = btn.querySelector('.jump-label').textContent;
+    btn.classList.add('opening');
+    btn.querySelector('.jump-label').textContent = 'Opening…';
+    try {
+      const res = await fetch('/api/open-in-desktop', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ session_id: currentSession.id }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        btn.querySelector('.jump-label').textContent = 'Opened!';
+        setTimeout(() => {
+          btn.classList.remove('opening');
+          btn.querySelector('.jump-label').textContent = origLabel;
+        }, 1500);
+      } else {
+        btn.querySelector('.jump-label').textContent = 'Failed: ' + (data.error || 'unknown');
+        setTimeout(() => {
+          btn.classList.remove('opening');
+          btn.querySelector('.jump-label').textContent = origLabel;
+        }, 3000);
+      }
+    } catch (err) {
+      btn.classList.remove('opening');
+      btn.querySelector('.jump-label').textContent = 'Error';
+      setTimeout(() => { btn.querySelector('.jump-label').textContent = origLabel; }, 2000);
+    }
+  }
+
   // ── Inject-to-terminal input bar ──
   const $convInputBar = document.getElementById('convInputBar');
   const $convInput = document.getElementById('convInput');
@@ -3545,6 +3617,7 @@
   for (const btn of allResumeButtons()) btn.addEventListener('click', copyResumeCommand);
   for (const btn of allJumpButtons()) btn.addEventListener('click', jumpToTerminal);
   for (const btn of allLaunchButtons()) btn.addEventListener('click', launchTerminal);
+  for (const btn of allDesktopButtons()) btn.addEventListener('click', openInClaudeDesktop);
 
   function formatSize(bytes) {
     if (bytes < 1024) return bytes + ' B';
@@ -7036,6 +7109,7 @@
   function updateSplitToolbar() {
     const $cpJumpBtn = document.getElementById('cpJumpBtn');
     const $cpLaunchBtn = document.getElementById('cpLaunchBtn');
+    const $cpDesktopBtn = document.getElementById('cpDesktopBtn');
     const $cpKillBtn = document.getElementById('cpKillBtn');
     if (!$cpJumpBtn) return;
     const sid = currentSession.id;
@@ -7079,6 +7153,34 @@
       } catch (_) {
         $cpLaunchBtn.innerHTML = '<span>&#43;</span> Launch';
       }
+    };
+    // Desktop: always show when a session is selected (not for pkood)
+    $cpDesktopBtn.style.display = (sid && !isPkood) ? '' : 'none';
+    $cpDesktopBtn.onclick = async () => {
+      if (!sid) return;
+      const origHTML = $cpDesktopBtn.innerHTML;
+      $cpDesktopBtn.textContent = 'Opening…';
+      $cpDesktopBtn.disabled = true;
+      let ok = false;
+      try {
+        const res = await fetch('/api/open-in-desktop', {
+          method: 'POST', headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({ session_id: sid }),
+        });
+        const data = await res.json();
+        if (data.ok) {
+          $cpDesktopBtn.textContent = 'Opened!';
+          ok = true;
+        } else {
+          $cpDesktopBtn.textContent = 'Failed: ' + (data.error || 'unknown');
+        }
+      } catch (_) {
+        $cpDesktopBtn.textContent = 'Error';
+      }
+      setTimeout(() => {
+        $cpDesktopBtn.innerHTML = origHTML;
+        $cpDesktopBtn.disabled = false;
+      }, ok ? 1500 : 3000);
     };
     // Kill: show for pkood
     $cpKillBtn.style.display = isPkood ? '' : 'none';

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -26,6 +26,22 @@ class TestServerImports(unittest.TestCase):
         self.assertIsInstance(server.__version__, str)
         self.assertRegex(server.__version__, r"^\d+\.\d+\.\d+")
 
+    def test_open_session_in_claude_desktop_rejects_bad_input(self):
+        """The helper exists and rejects empty / non-UUID session IDs
+        without trying to spawn `open(1)`."""
+        for mod in ("server", "morning", "morning_store"):
+            sys.modules.pop(mod, None)
+        server = importlib.import_module("server")
+        self.assertTrue(hasattr(server, "open_session_in_claude_desktop"))
+        # Empty
+        r = server.open_session_in_claude_desktop("")
+        self.assertFalse(r["ok"])
+        self.assertIn("error", r)
+        # Not a UUID
+        r = server.open_session_in_claude_desktop("not-a-uuid")
+        self.assertFalse(r["ok"])
+        self.assertIn("error", r)
+
     def test_morning_disabled_when_plugin_absent(self):
         """If morning.py isn't importable, MORNING_ENABLED must be False
         no matter what CCC_ENABLE_MORNING says."""


### PR DESCRIPTION
## Summary

- Adds a third destination button beside Jump/Launch in the conversation toolbar (and the conversation-pane chrome) that opens the macOS Claude Desktop GUI app and resumes the current session via `claude://resume?session=<uuid>`.
- The desktop app handles the deep-link by importing the CLI session and navigating to it (verified by reading the registered handler in `Claude.app`'s main process JS).
- Backend helper validates the session_id as a UUID and shells out to `open(1)` with an argv list — no shell, no injection surface. Endpoint inherits the existing same-origin CSRF guard.
- macOS only for now (relies on `open(1)`); non-Darwin returns a clear error.

## Files changed (~178 lines)

- `server.py` — new `open_session_in_claude_desktop` helper + `POST /api/open-in-desktop` route
- `static/index.html` — `.desktop-btn` CSS, two button surfaces, JS wiring in `updateJumpButton` + `updateSplitToolbar`, `openInClaudeDesktop` click handler
- `tests/test_smoke.py` — assertion that the helper exists and rejects empty / non-UUID input
- `pyproject.toml` + `server.py` — version bumped 0.1.3 → 0.2.0
- `CHANGELOG.md` + `README.md` — feature bullet

## Test plan

- [x] `python3 -m unittest tests.test_smoke -v` → 4/4 pass
- [x] `curl POST /api/open-in-desktop` with bad UUID → `{"ok": false, "error": "invalid session_id (expected UUID)"}`
- [x] Same with empty body → `{"ok": false, "error": "missing session_id"}`
- [x] Same with wrong Origin → 403 `cross-origin POST rejected`
- [ ] Click button on a live session → Claude Desktop opens to that session
- [ ] Click on a dormant session → Claude Desktop opens to that session
- [ ] Pkood session → conv-pane button hidden (toolbar button visible, mirrors Jump/Launch pre-existing pattern)
- [ ] Visually inspect the `▤` icon glyph at toolbar size — swap if it doesn't read as "desktop"

🤖 Generated with [Claude Code](https://claude.com/claude-code)