### PR TITLE
feat(ui): drop Inactive column; add "no edits" chip

### DIFF
--- a/changelog.d/changed-no-edits-chip-2026-04-28.md
+++ b/changelog.d/changed-no-edits-chip-2026-04-28.md
@@ -1,0 +1,10 @@
+- **Dropped the `Inactive` column; replaced with a small "no edits" chip.**
+  Sessions that used to land in `Inactive` (dead, no commits, no edits) now
+  sit inside `Working`. A small lowercase blue **"no edits"** chip — sitting
+  alongside `pushed` / `committed` in the list view, and next to the stage
+  chip in the kanban — flags any session whose Claude has never touched a
+  file. Liveness deliberately doesn't matter: a freshly-spawned session with
+  no tool calls yet shows the chip just like a dormant shell does. Driven by
+  a small `hasNoEdits(c)` helper: `!c.has_edit && !c.verified && !c.archived`
+  (no labels, no stage, no liveness checks — the chip describes one thing).
+  Stale `inactive` localStorage overrides drop on first render.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,7 +94,7 @@ All three converge into the same card model in the UI.
 
 `classifyKanbanColumn` (client-side, in `static/index.html`) takes a session
 entry and returns one of: `backlog / needs-attention / icebox / working /
-review / testing / verified / archived / inactive`. The rules:
+waiting / review / testing / verified / archived`. The rules:
 
 ```
 archived flag           -> archived
@@ -108,8 +108,14 @@ pushed / committed      -> review
 not live + edits + assistant-last -> review
 needs-attention label   -> needs-attention
 claude-in-progress (dead) -> working
-otherwise               -> inactive
+otherwise               -> working       (dead + empty — render adds a blue
+                                          "no edits" chip via hasNoEdits())
 ```
+
+A separate `hasNoEdits(c)` helper drives a small blue **"no edits"** chip in
+both the list view and the kanban card. Liveness is irrelevant — any session
+whose Claude has never touched a file gets the chip, so you can spot
+resumable shells (and pre-tool fresh sessions) without a separate column.
 
 The full annotated list lives in [`kanban-rules.md`](kanban-rules.md), with a
 draggable diagram in [`kanban-rules.html`](kanban-rules.html).
@@ -117,8 +123,8 @@ draggable diagram in [`kanban-rules.html`](kanban-rules.html).
 Manual drag-drop writes a client-side override into `localStorage`
 (`ccc-column-overrides`). Overrides auto-clear only when the session's natural
 state advances past the override (e.g., an override of `working` is dropped
-once the session's commits get pushed). Stale `planning` overrides from older
-builds are dropped on first render.
+once the session's commits get pushed). Stale `planning` and `inactive`
+overrides from older builds are dropped on first render.
 
 ## Hooks
 

--- a/docs/kanban-rules.html
+++ b/docs/kanban-rules.html
@@ -174,10 +174,9 @@
     { id: 'backlog',         x:  20, y:  40, label: 'backlog',         hint: 'open issues + TODO',           cls: 'intake' },
     { id: 'needs-attention', x: 220, y:  40, label: 'needs-attention', hint: 'label: needs-attention',       cls: 'intake' },
     { id: 'icebox',          x: 120, y: 220, label: 'icebox',          hint: 'parked — icebox label or drag', cls: 'intake' },
-    { id: 'working',         x: 370, y: 220, label: 'working',         hint: 'live session — Claude is running', cls: 'live' },
+    { id: 'working',         x: 370, y: 220, label: 'working',         hint: 'live session OR resumable idle', cls: 'live' },
     { id: 'review',          x: 620, y: 220, label: 'review',          hint: 'committed/pushed, dead',       cls: 'review' },
     { id: 'testing',         x: 870, y: 220, label: 'testing',         hint: 'manual only',                  cls: '' },
-    { id: 'inactive',        x:1100, y: 220, label: 'inactive',        hint: 'dormant fallback',             cls: '' },
     { id: 'verified',        x: 370, y: 450, label: 'verified',        hint: 'flag + GH closed COMPLETED',   cls: 'terminal' },
     { id: 'archived',        x: 620, y: 450, label: 'archived',        hint: 'flag + GH closed not-planned', cls: 'terminal' },
   ];
@@ -197,7 +196,6 @@
     // Working flows
     { from: 'working',         to: 'icebox',          kind: 'explicit', label: ['drag → icebox', 'or label icebox added'] },
     { from: 'working',         to: 'review',          kind: 'implicit', label: ['commit / push', '(after process exits)'] },
-    { from: 'working',         to: 'inactive',        kind: 'implicit', label: ['process exits, no tools used'] },
     { from: 'working',         to: 'archived',        kind: 'explicit', label: ['drag (rare)'] },
 
     // Icebox exit
@@ -212,7 +210,6 @@
     { from: 'testing',         to: 'verified',        kind: 'explicit', label: ['drag → verified'] },
 
     // Resurrections from terminal columns
-    { from: 'inactive',        to: 'working',         kind: 'implicit', label: ['resume + tool fires'] },
     { from: 'archived',        to: 'working',         kind: 'explicit', label: ['drag out → clears archived'] },
     { from: 'verified',        to: 'working',         kind: 'explicit', label: ['drag out → clears flag'] },
   ];
@@ -433,10 +430,9 @@
   <li>!live + edits + last=assistant → <b>review</b> (dormant w/ unsaved edits)</li>
   <li>label needs-attention → <b>needs-attention</b></li>
   <li>label claude-in-progress → <b>working</b></li>
-  <li>!live + no sidecar → <b>inactive</b></li>
   <li>Live + pkood (any state) → <b>working</b></li>
   <li>Live (any other) → <b>working</b></li>
-  <li>Fallback → <b>inactive</b></li>
+  <li>Fallback → <b>working</b> · render adds the blue <b>Idle</b> pill if <code>isIdleSession()</code></li>
 </ol>
 </div>
 
@@ -504,7 +500,7 @@
     </tr>
     <tr>
       <td><span class="pill implicit">process</span> Claude exits</td>
-      <td><code>is_live=false</code> · has commits/edits → <b>review</b> · else → <b>inactive</b></td>
+      <td><code>is_live=false</code> · has commits/edits → <b>review</b> · else → <b>working</b> with Idle pill</td>
       <td><code>ps -A</code> mismatch in /api/sessions</td>
     </tr>
     <tr>
@@ -534,7 +530,7 @@
     </tr>
     <tr>
       <td><span class="pill implicit">label</span> claude-in-progress (dead session)</td>
-      <td>inactive / review → <b>working</b> ("this is the active branch")</td>
+      <td>review (or idle) → <b>working</b> ("this is the active branch")</td>
       <td>/api/sessions enrich</td>
     </tr>
     <tr>

--- a/docs/kanban-rules.md
+++ b/docs/kanban-rules.md
@@ -22,7 +22,16 @@ order:
 | `testing` | In Testing | Manually moved here. No automatic routing in or out |
 | `verified` | Verified | Marked done, or the linked GitHub issue closed as `COMPLETED` |
 | `archived` | Archived | Dismissed, or issue closed for any non-completed reason |
-| `inactive` | Inactive | Dead session that never used a tool — graveyard / resumable shelf |
+
+> **What changed (Inactive column → "no edits" chip).** The `Inactive` column is gone.
+> Sessions that used to land there (dead, no commits) now sit inside `Working`. A small
+> blue **"no edits"** chip — driven by `hasNoEdits(c)` — flags any session whose Claude
+> has never touched a file, regardless of whether the process is alive. Stale `inactive`
+> localStorage overrides drop on first render after upgrade.
+
+`hasNoEdits(c)` is intentionally simple: `!c.has_edit && !c.verified &&
+!c.archived && c.source !== 'backlog'`. Liveness, labels, and stage are
+deliberately ignored — the chip describes one thing only.
 
 > **What changed (planning → icebox refactor).** The old `planning` column conflated two
 > unrelated states: a transient "live but no tool fired yet" pre-window, and a long-lived
@@ -60,10 +69,9 @@ Rules are checked in this order; the first match wins:
 9. !live + 'coding' + last=assistant                    → review   (dormant w/ unsaved edits)
 10. label needs-attention                               → needs-attention
 11. label claude-in-progress                            → working
-12. !live + no sidecar                                  → inactive
-13. live + pkood (any state)                            → working
-14. live (any other)                                    → working
-15. fallback                                            → inactive
+12. live + pkood (any state)                            → working
+13. live (any other)                                    → working
+14. fallback                                            → working   (with Idle pill if isIdleSession)
 ```
 
 The `testing` column is **never** assigned by the classifier. The only way
@@ -148,7 +156,7 @@ No code "moves" the card here. The signals change and the next render of
 - `is_live` flips to false. Sidecar file remains.
 - Effect depends on stage:
   - has commits or edits + last was assistant → `review` (rules 8–9)
-  - nothing meaningful happened → `inactive` (rule 12)
+  - nothing meaningful happened → `working` (rule 14, card gets the Idle pill)
 
 ### Git commit / push lands
 - Detected by `sessionStage()` reading `git log` ([`server.py`](../server.py))

--- a/static/index.html
+++ b/static/index.html
@@ -1304,6 +1304,7 @@
   .conv-signal.activity-blocked { background: rgba(248,81,73,0.15); color: var(--red); animation: pulse 2s infinite; }
   .conv-signal.pkood-running { background: rgba(63,185,80,0.15); color: var(--green); }
   .conv-signal.pkood-idle { background: rgba(88,166,255,0.1); color: var(--accent); }
+  .conv-signal.no-edits { background: rgba(88,166,255,0.1); color: var(--accent); }
   .conv-signal.pkood-blocked { background: rgba(248,81,73,0.15); color: var(--red); animation: pulse 2s infinite; }
   .conv-signal.pkood-stuck { background: rgba(248,81,73,0.25); color: var(--red); font-weight: 700; }
   .conv-item .source-badge.pkood { background: rgba(210,153,34,0.2); color: var(--orange); }
@@ -1467,7 +1468,6 @@
   .kanban-column.working  .kanban-card { background: linear-gradient(rgba(210,153,34,0.16), rgba(210,153,34,0.16)), var(--surface); }
   .kanban-column.review   .kanban-card { background: linear-gradient(rgba(57,210,192,0.14), rgba(57,210,192,0.14)), var(--surface); }
   .kanban-column.testing  .kanban-card { background: linear-gradient(rgba(251,202,4,0.14), rgba(251,202,4,0.14)), var(--surface); }
-  .kanban-column.inactive .kanban-card { background: linear-gradient(rgba(139,148,158,0.06), rgba(139,148,158,0.06)), var(--surface); }
   .kanban-column.verified .kanban-card { background: linear-gradient(rgba(63,185,80,0.16), rgba(63,185,80,0.16)), var(--surface); }
   .kanban-column.archived .kanban-card { background: linear-gradient(rgba(139,148,158,0.04), rgba(139,148,158,0.04)), var(--surface); }
   .kanban-column-header { cursor: grab; }
@@ -1506,8 +1506,6 @@
   .kanban-column.review .count { background: rgba(57,210,192,0.2); color: var(--cyan); }
   .kanban-column.backlog .kanban-column-header { color: var(--text-muted); }
   .kanban-column.backlog .count { background: rgba(139,148,158,0.15); color: var(--text-muted); }
-  .kanban-column.inactive .kanban-column-header { color: var(--text-muted); }
-  .kanban-column.inactive .count { background: rgba(139,148,158,0.15); color: var(--text-muted); }
   .kanban-column.testing .kanban-column-header { color: #FBCA04; }
   .kanban-column.testing .count { background: rgba(251,202,4,0.2); color: #FBCA04; }
   .kanban-column.archived .kanban-column-header { color: var(--text-muted); opacity: 0.6; }
@@ -1530,6 +1528,10 @@
     animation: working-glow 1.6s ease-in-out infinite !important;
     border: 1px solid rgba(251,202,4,0.4) !important;
   }
+  /* "no edits" attribute: shown on cards whose Claude has never edited a file
+     (live or dead — liveness doesn't matter). Renders as a small lowercase
+     blue chip next to the stage chip. No card-level dimming so cards stay
+     scannable. */
   /* Pending (optimistic placeholder while /api/sessions/spawn is in flight)
      and recently-born (the real session that replaced it, or any session
      that first appeared during a live poll) share one shimmer style so the
@@ -1661,6 +1663,7 @@
   .kanban-card .kanban-card-stage.stage { background: rgba(188,140,255,0.15); color: var(--purple); }
   .kanban-card .kanban-card-stage.committed { background: rgba(63,185,80,0.15); color: var(--green); }
   .kanban-card .kanban-card-stage.testing { background: rgba(251,202,4,0.15); color: #FBCA04; }
+  .kanban-card .kanban-card-stage.no-edits { background: rgba(88,166,255,0.1); color: var(--accent); margin-left: 4px; }
   .kanban-issue-badge {
     display: inline-block; font-size: 14px; padding: 2px 8px;
     border-radius: 4px; margin-right: 8px; font-weight: 700;
@@ -5927,9 +5930,10 @@
       const stage = sessionStage(c);
       const ghClosed = (c.gh_state || '').toUpperCase() === 'CLOSED';
       const stale =
-        // Migration: 'planning' was renamed to 'icebox' in the planning→icebox
-        // refactor. Drop any leftover overrides from older builds on first render.
-        ov === 'planning' ||
+        // Migration: 'planning' was renamed to 'icebox' (planning→icebox refactor)
+        // and the 'inactive' column was dropped (idle is now an attribute on
+        // Working cards). Drop any leftover overrides from older builds.
+        ov === 'planning' || ov === 'inactive' ||
         // Server truth wins: verified/archived cannot coexist with an active-work override.
         c.verified || c.archived ||
         // Only flag working/icebox as stale when work has truly shipped (pushed)
@@ -5985,8 +5989,23 @@
     // belongs in Working (the label says this is the active work).
     if (hasLabel('claude-in-progress')) return 'working';
 
-    // Fallback: never hide anything — every session gets a column.
-    return 'inactive';
+    // Fallback: dead session with no commits/edits/labels. Used to land in a
+    // separate 'inactive' column; now lives in Working. The "no edits" chip
+    // (see hasNoEdits) flags any card — live or dead — that has yet to touch
+    // a file, so the user can spot resumable shells without a separate column.
+    return 'working';
+  }
+
+  // True when this session has never edited a file. Drives the "no edits"
+  // chip in both the list view and the kanban card. Doesn't care about
+  // liveness — a live session that hasn't touched anything yet is just as
+  // "no edits" as a dead one. Excludes verified / archived (terminal state,
+  // chip is noise) and backlog (different render path).
+  function hasNoEdits(c) {
+    if (!c) return false;
+    if (c.verified || c.archived) return false;
+    if (c.source === 'backlog') return false;
+    return !c.has_edit;
   }
 
   function renderKanbanBoard(convs, targetEl, isSplit) {
@@ -5999,11 +6018,9 @@
       { key: 'icebox',          label: 'Icebox',          defaultExpanded: true,
         hint: 'Parked. The `icebox` GitHub label is set, or you dragged it here. Active intent: don\'t work on this right now.' },
       { key: 'working',         label: 'Working',         defaultExpanded: true,
-        hint: 'Live session — Claude is running. Glows when mid-turn.' },
+        hint: 'Live or resumable sessions. Idle ones (no commits / no live process) get a blue Idle pill — pick one back up by jumping in.' },
       { key: 'waiting',         label: 'Waiting',         defaultExpanded: true,
         hint: 'Claude is asking for permission (Notification hook). Approve or deny in the terminal.' },
-      { key: 'inactive',        label: 'Inactive',        defaultExpanded: false,
-        hint: 'Dead sessions that never produced commits. Resume from here when you pick one back up.' },
       { key: 'review',          label: 'Review',          defaultExpanded: true,
         hint: 'Committed or pushed work waiting for you to read and verify.' },
       { key: 'testing',         label: 'In Testing',      defaultExpanded: true,
@@ -6028,7 +6045,11 @@
       const col = classifyKanbanColumn(c);
       if (col && groups[col]) groups[col].push(c);
     }
-    // Within "Working", sort actively-writing sessions to the top.
+    // Within "Working": actively-writing sessions sort to the top so glow
+    // animations stay visible. Idle (resumable, no commits) cards otherwise
+    // mix with live work in natural order — the blue Idle pill is enough
+    // visual distinction; sinking them to the bottom would hide them behind
+    // the column's maxVisible cap when Working is busy.
     if (groups.working) {
       groups.working.sort((a, b) => {
         const aActive = a.is_live && a.sidecar_status === 'active' && a.sidecar_has_writes ? 1 : 0;
@@ -6062,13 +6083,12 @@
           'backlog': 'No open issues or TODO items.',
           'needs-attention': 'Nothing flagged for triage.',
           'icebox': 'Nothing parked. Drag a card here, or label its issue `icebox`, to park it.',
-          'working': 'No live sessions.',
+          'working': 'No live or idle sessions.',
           'waiting': 'No sessions waiting for approval.',
           'review': 'Nothing waiting for review.',
           'testing': 'Drag cards here to mark as testing.',
           'verified': 'No verified work yet.',
           'archived': 'No archived items.',
-          'inactive': 'No dormant sessions.',
         }[col.key] || 'Empty.';
         html += '<div class="kanban-column-empty" style="padding:14px 12px;color:var(--text-muted);font-size:11px;font-style:italic;text-align:center;opacity:0.6;">' + escapeHtml(emptyMsg) + '</div>';
       }
@@ -6238,7 +6258,8 @@
         const trulyActive = c.is_live && c.sidecar_status === 'active' && (sidecarAge < 300 || midTurn) ? ' truly-active' : '';
         const pendingSpawn = c.pending_spawn ? ' pending-spawn' : '';
         const recentlyBorn = isRecentlyBorn(c.session_id) ? ' recently-born' : '';
-        html += '<div class="kanban-card' + active + trulyActive + pendingSpawn + recentlyBorn + '" draggable="true" data-id="' + c.id + '" data-session-id="' + escapeHtml(c.session_id || c.id) + '" data-col="' + colKey + '">';
+        const noEditsAttr = hasNoEdits(c) ? ' no-edits' : '';
+        html += '<div class="kanban-card' + active + trulyActive + pendingSpawn + recentlyBorn + noEditsAttr + '" draggable="true" data-id="' + c.id + '" data-session-id="' + escapeHtml(c.session_id || c.id) + '" data-col="' + colKey + '">';
         // Create-issue button only when no issue is linked. The "view issue" link
         // was removed — tapping the #NNN badge in the title opens the issue.
         const linkedIssue = c.linked_issue || c.issue_number || '';
@@ -6331,6 +6352,9 @@
             + '</div>';
         }
         html += '<div class="kanban-card-stage ' + stageCls + '">' + escapeHtml(stageLabel) + '</div>';
+        if (noEditsAttr) {
+          html += '<span class="kanban-card-stage no-edits" title="Claude has not edited any files in this session">no edits</span>';
+        }
 
         // ── Task 8: Approve/Deny for waiting cards with pending_tool ──
         // Live "what's running right now" \u2014 render whenever sidecar shows
@@ -7268,6 +7292,8 @@
         signals += '<span class="conv-signal pushed">pushed</span>';
       } else if (c.has_commit) {
         signals += '<span class="conv-signal committed">committed</span>';
+      } else if (hasNoEdits(c)) {
+        signals += '<span class="conv-signal no-edits" title="Claude has not edited any files in this session">no edits</span>';
       }
       // Two "uncommitted" pills, additive on top of the chain above.
       // We deliberately render BOTH while we watch them for agreement


### PR DESCRIPTION
## Summary

- **Inactive column gone** as a separate bucket. Sessions that used to land there (dead, no commits, no edits) now sit inside `Working`.
- **New `no edits` chip** flags any session whose Claude has never touched a file. Lowercase blue, sits in the same lane as `pushed` / `committed` in the list view and next to the stage chip on kanban cards. Liveness deliberately doesn't matter — a freshly-spawned session with no tool calls yet shows the chip just like a dormant shell does.
- **Classifier simplification.** The 15-rule set shrinks to ~10 by collapsing all live cases into Working and dropping the dedicated Inactive fallback. The `hasNoEdits(c)` helper is one line: `!c.has_edit && !c.verified && !c.archived && c.source !== 'backlog'` — no labels, stage, or liveness checks.
- **Migration.** Stale `inactive` and `planning` localStorage overrides drop on first render after upgrade.

Composes cleanly with the just-merged "dual uncommitted pills" — `tools` / `git` chips fire when there ARE edits but no commit, `no edits` fires when there are none. Mutually exclusive by definition; both can render on the same row in different conditions.

## Test plan

- [ ] Hard-refresh the UI and confirm the Inactive column is gone from both list and kanban views.
- [ ] Confirm sessions whose Claude never edited a file show a small blue lowercase `no edits` chip on the right (list) / next to the stage (kanban).
- [ ] Confirm pushed/committed sessions still show their existing chips and don't get `no edits`.
- [ ] Confirm verified/archived sessions don't get `no edits` (chip is silent for terminal state).
- [ ] Confirm classifier no longer returns `inactive` in any code path.
- [ ] Sanity-check that any old `columnOverrides[sid] = 'inactive'` in localStorage gets dropped silently after one render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)