### PR TITLE
feat: cost pill, worktree-per-spawn, macOS notifications

### DIFF
--- a/changelog.d/added-cost-pill-2026-04-27.md
+++ b/changelog.d/added-cost-pill-2026-04-27.md
@@ -1,0 +1,9 @@
+**Cost pill in the conv-pane input strip.** Next to the existing `ctx` pill,
+a small `$0.34` chip surfaces the Anthropic API list-price equivalent for
+the session's tokens. Hover for a per-category breakdown (input, cache
+write, cache read, output) with token counts. Subscription users (Claude
+Pro/Max) pay flat, but the figure is the cleanest cross-model "how
+expensive was this session" comparison. Server: `extract_session_usage` now
+returns `cost_usd`, `cost_breakdown_usd`, and the per-category token totals
+on `/api/session/<id>/usage`. Rate table covers Opus 4 / Sonnet 4 / Haiku 4
+and falls back to Sonnet rates for unknown models.

--- a/changelog.d/added-macos-notifications-2026-04-27.md
+++ b/changelog.d/added-macos-notifications-2026-04-27.md
@@ -1,0 +1,17 @@
+**macOS native notifications when Claude needs your attention.** The
+`Stop` and `Notification` hooks now fire `osascript display notification`
+banners alongside their existing sidecar writes, so you see a system-tray
+ping even when CCC isn't focused (or is on another desktop space). Two
+events:
+
+- **Claude finished a turn** (Stop hook) → "Ready for your input" banner
+  with the session-id prefix as subtitle.
+- **Claude needs approval** (Notification hook) → "Claude needs your
+  approval" banner with the permission-prompt message as the body.
+
+Opt-out via `CCC_NOTIFY=0` in the shell env. Falls through silently on
+non-macOS systems (no `osascript` on PATH). Banners are fire-and-forget
+via `subprocess.Popen` — hooks never block on notification delivery.
+Browser-side `Notification` API can come later as a follow-up; this
+covers the "I'm on my Mac and switched away from CCC" case which is the
+most common one.

--- a/changelog.d/added-worktree-per-spawn-2026-04-27.md
+++ b/changelog.d/added-worktree-per-spawn-2026-04-27.md
@@ -1,0 +1,12 @@
+**Worktree-per-spawn checkbox.** A new `🌿 worktree` toggle next to the
+existing `pkood spawn` toggle (in both the inline new-session row and the
+new-session modal) lets you launch the session in a fresh git worktree on
+a `feat/<slug>` branch, isolated from main. When enabled, CCC runs `git
+worktree add <repo-parent>/<repo-name>-wt-<slug> -b feat/<slug>` against
+the source repo before spawning Claude there — so the agent literally
+cannot accidentally commit to main even if it ignores the multi-agent
+git-hygiene rules. Path collisions get a numeric suffix (`...-wt-foo-2`),
+branch collisions get the same suffix on the branch name. New optional
+`worktree: bool` field on `POST /api/sessions/spawn`; response gains
+`worktree_path` and `worktree_branch` when applicable. `pkood` spawns
+ignore the flag (out of scope).

--- a/hooks/_notify.py
+++ b/hooks/_notify.py
@@ -1,0 +1,50 @@
+"""Tiny stdlib helper for firing macOS notifications from CCC hooks.
+
+Used by stop.py (Claude finished a turn — needs input) and notification.py
+(Claude is asking for permission). Stays a separate file so the hooks
+themselves remain trivial.
+
+Disabled gracefully when:
+- CCC_NOTIFY=0 in the environment (opt-out)
+- osascript isn't on PATH (non-macOS)
+- the user's display is locked / the call fails — Popen is fire-and-forget
+  so a hook never blocks on notification delivery
+"""
+
+import os
+import shutil
+import subprocess
+
+
+def _enabled():
+    return os.environ.get("CCC_NOTIFY", "1") != "0"
+
+
+def _esc(s):
+    """Escape characters that would break out of an AppleScript string
+    literal. Keep it simple: backslash, double-quote, and trim length so
+    a 5KB tool error doesn't end up in the notification banner."""
+    s = s or ""
+    return s.replace("\\", "\\\\").replace('"', '\\"')[:240]
+
+
+def notify(title, message, subtitle=""):
+    if not _enabled():
+        return
+    osascript = shutil.which("osascript")
+    if not osascript:
+        return
+    script_parts = [f'display notification "{_esc(message)}"',
+                    f'with title "{_esc(title)}"']
+    if subtitle:
+        script_parts.append(f'subtitle "{_esc(subtitle)}"')
+    script = " ".join(script_parts)
+    try:
+        subprocess.Popen(
+            [osascript, "-e", script],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except OSError:
+        pass

--- a/hooks/notification.py
+++ b/hooks/notification.py
@@ -19,6 +19,13 @@ import os
 import sys
 import time
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    from _notify import notify
+except ImportError:
+    def notify(*_a, **_k):
+        pass
+
 LIVE_STATE_DIR = os.path.expanduser("~/.claude/command-center/live-state")
 
 
@@ -33,9 +40,10 @@ def main():
 
         os.makedirs(LIVE_STATE_DIR, exist_ok=True)
 
+        message = data.get("message", "")
         marker = {
             "session_id": session_id,
-            "message": data.get("message", ""),
+            "message": message,
             "type": data.get("type", ""),
             "started_at": time.time(),
         }
@@ -45,6 +53,15 @@ def main():
         with open(tmp, "w") as f:
             json.dump(marker, f)
         os.replace(tmp, path)
+
+        # macOS banner so the user knows Claude is blocked on a permission
+        # prompt even when CCC isn't focused. Falls through silently on
+        # non-macOS systems or when CCC_NOTIFY=0.
+        notify(
+            title="Claude needs your approval",
+            message=message or "Permission requested",
+            subtitle=session_id[:8],
+        )
 
     except Exception:
         pass

--- a/hooks/stop.py
+++ b/hooks/stop.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python3
-"""Stop hook — marks session as waiting for input."""
+"""Stop hook — marks session as waiting for input.
+
+Also fires a macOS notification ("Claude is waiting for you") via the
+shared _notify helper so the user sees a banner even when CCC isn't
+focused. Opt-out: CCC_NOTIFY=0 in the env.
+"""
 
 import json
 import os
 import sys
 import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    from _notify import notify
+except ImportError:
+    def notify(*_a, **_k):
+        pass
 
 LIVE_STATE_DIR = os.path.expanduser("~/.claude/command-center/live-state")
 
@@ -35,6 +47,15 @@ def main():
         with open(tmp_path, "w") as f:
             json.dump(state, f)
         os.replace(tmp_path, state_path)
+
+        # Subtitle = short session id so the user can match the banner to a
+        # card in the kanban without us having to open the JSONL to fetch
+        # the prompt. Trade-off: less context, but stays fast.
+        notify(
+            title="Claude Command Center",
+            message="Ready for your input",
+            subtitle=session_id[:8],
+        )
 
     except Exception:
         pass

--- a/server.py
+++ b/server.py
@@ -6898,6 +6898,36 @@ def extract_session_timeline(session_id):
     return {"events": events, "total_turns": turn}
 
 
+# Anthropic API list-price rates ($ per million tokens) by model family.
+# Subscription users (Claude Pro / Max / API console credits) don't pay these
+# rates per turn, but the breakdown is still the cleanest signal of "how
+# expensive is this session" — same units for everyone, comparable across
+# models. UI surfaces this as "API list-price equivalent".
+#
+# Sources: anthropic.com/pricing as of 2026-04. If rates change, edit here;
+# the model match is substring-based so claude-opus-4-7 / -4-7[1m] / future
+# minor bumps fall through to the same family rate.
+_MODEL_RATES = [
+    # (substring_match, input_per_mtok, cache_write, cache_read, output_per_mtok)
+    ("opus-4",   15.00, 18.75,  1.50, 75.00),
+    ("sonnet-4",  3.00,  3.75,  0.30, 15.00),
+    ("haiku-4",   1.00,  1.25,  0.10,  5.00),
+    # Older families kept for archival sessions.
+    ("opus-3",   15.00, 18.75,  1.50, 75.00),
+    ("sonnet-3",  3.00,  3.75,  0.30, 15.00),
+    ("haiku-3",  0.25,  0.30,  0.03,  1.25),
+]
+_FALLBACK_RATES = (3.00, 3.75, 0.30, 15.00)  # Sonnet — sane middle ground.
+
+
+def _rates_for_model(model):
+    m = (model or "").lower()
+    for substr, *rates in _MODEL_RATES:
+        if substr in m:
+            return rates
+    return list(_FALLBACK_RATES)
+
+
 def extract_session_usage(session_id):
     """Walk a session's JSONL transcript and return token-usage stats.
 
@@ -6908,14 +6938,22 @@ def extract_session_usage(session_id):
     turns is the closest the session got to the model's context limit.
 
     Returns: {latest_input_tokens, peak_input_tokens, total_output_tokens,
-              model, context_limit}
+              total_input_tokens, total_cache_creation_tokens,
+              total_cache_read_tokens, model, context_limit, cost_usd,
+              cost_breakdown_usd}.
     """
     empty = {
         "latest_input_tokens": 0,
         "peak_input_tokens": 0,
         "total_output_tokens": 0,
+        "total_input_tokens": 0,
+        "total_cache_creation_tokens": 0,
+        "total_cache_read_tokens": 0,
         "model": "",
         "context_limit": 0,
+        "cost_usd": 0.0,
+        "cost_breakdown_usd": {"input": 0.0, "cache_creation": 0.0,
+                               "cache_read": 0.0, "output": 0.0},
     }
     if not PROJECTS_ROOT.is_dir():
         return empty
@@ -6932,6 +6970,9 @@ def extract_session_usage(session_id):
 
     latest = 0
     peak = 0
+    total_in = 0
+    total_cw = 0
+    total_cr = 0
     total_out = 0
     model = ""
     try:
@@ -6954,16 +6995,23 @@ def extract_session_usage(session_id):
                 u = msg.get("usage") or {}
                 if not isinstance(u, dict):
                     continue
-                inp = (u.get("input_tokens") or 0) \
-                    + (u.get("cache_creation_input_tokens") or 0) \
-                    + (u.get("cache_read_input_tokens") or 0)
-                out = u.get("output_tokens") or 0
-                if inp:
-                    latest = inp
-                    if inp > peak:
-                        peak = inp
-                if isinstance(out, int):
-                    total_out += out
+                ti = u.get("input_tokens") or 0
+                tcw = u.get("cache_creation_input_tokens") or 0
+                tcr = u.get("cache_read_input_tokens") or 0
+                tout = u.get("output_tokens") or 0
+                window = ti + tcw + tcr
+                if window:
+                    latest = window
+                    if window > peak:
+                        peak = window
+                if isinstance(ti, int):
+                    total_in += ti
+                if isinstance(tcw, int):
+                    total_cw += tcw
+                if isinstance(tcr, int):
+                    total_cr += tcr
+                if isinstance(tout, int):
+                    total_out += tout
     except OSError:
         return empty
 
@@ -6977,12 +7025,30 @@ def extract_session_usage(session_id):
         limit = 1_000_000
     else:
         limit = 200_000
+
+    rate_in, rate_cw, rate_cr, rate_out = _rates_for_model(model)
+    cost_in = total_in * rate_in / 1_000_000
+    cost_cw = total_cw * rate_cw / 1_000_000
+    cost_cr = total_cr * rate_cr / 1_000_000
+    cost_out = total_out * rate_out / 1_000_000
+    cost_total = cost_in + cost_cw + cost_cr + cost_out
+
     return {
         "latest_input_tokens": latest,
         "peak_input_tokens": peak,
         "total_output_tokens": total_out,
+        "total_input_tokens": total_in,
+        "total_cache_creation_tokens": total_cw,
+        "total_cache_read_tokens": total_cr,
         "model": model,
         "context_limit": limit,
+        "cost_usd": round(cost_total, 4),
+        "cost_breakdown_usd": {
+            "input": round(cost_in, 4),
+            "cache_creation": round(cost_cw, 4),
+            "cache_read": round(cost_cr, 4),
+            "output": round(cost_out, 4),
+        },
     }
 
 

--- a/server.py
+++ b/server.py
@@ -4259,11 +4259,81 @@ def _slugify(text, max_len=40):
     return slug[:max_len].rstrip("-")
 
 
-def spawn_session(prompt, name=None, cwd=None):
+def _create_worktree_for_spawn(source_cwd, slug):
+    """Create `<source-parent>/<source-name>-wt-<slug>` as a git worktree
+    on a fresh `feat/<slug>` branch off `source_cwd`'s current HEAD, and
+    return its absolute path.
+
+    Layout matches the convention already used in this repo's worktrees
+    (e.g. `claude-command-center-wt-desktop-launch`) — sibling-dir style
+    rather than nested under the source so editors / `find` calls don't
+    accidentally recurse into them.
+
+    Returns (path, branch) on success, raises RuntimeError on any failure
+    (not-a-repo, dirty index, branch collision, etc.) so the caller can
+    surface a clean error to the spawn API. Caller is responsible for
+    deciding whether to fall back to no-worktree mode or fail the spawn.
+    """
+    p = Path(source_cwd).expanduser().resolve()
+    if not p.is_dir():
+        raise RuntimeError(f"source cwd does not exist: {p}")
+    # Resolve to the toplevel so worktree creation works whether the
+    # caller pointed at the repo root or a subdir within it.
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(p), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=3, check=True,
+        )
+    except (subprocess.SubprocessError, OSError) as e:
+        raise RuntimeError(f"source cwd is not a git repo: {e}")
+    toplevel = Path(r.stdout.strip())
+    parent = toplevel.parent
+    base_name = toplevel.name
+    # Pick the first non-existing variant of `<base>-wt-<slug>[-N]`.
+    candidate = parent / f"{base_name}-wt-{slug}"
+    suffix = 2
+    while candidate.exists():
+        candidate = parent / f"{base_name}-wt-{slug}-{suffix}"
+        suffix += 1
+    branch = f"feat/{slug}"
+    # If the branch already exists, append the same numeric suffix the
+    # path got so they stay aligned.
+    branch_check = subprocess.run(
+        ["git", "-C", str(toplevel), "rev-parse", "--verify", branch],
+        capture_output=True, text=True, timeout=3,
+    )
+    if branch_check.returncode == 0:
+        # Branch exists — pick a fresh one matching the path suffix.
+        branch_suffix = 2
+        while True:
+            cand_branch = f"feat/{slug}-{branch_suffix}"
+            check = subprocess.run(
+                ["git", "-C", str(toplevel), "rev-parse", "--verify", cand_branch],
+                capture_output=True, text=True, timeout=3,
+            )
+            if check.returncode != 0:
+                branch = cand_branch
+                break
+            branch_suffix += 1
+    add = subprocess.run(
+        ["git", "-C", str(toplevel), "worktree", "add", str(candidate), "-b", branch],
+        capture_output=True, text=True, timeout=15,
+    )
+    if add.returncode != 0:
+        raise RuntimeError(f"git worktree add failed: {add.stderr.strip() or add.stdout.strip()}")
+    return str(candidate), branch
+
+
+def spawn_session(prompt, name=None, cwd=None, worktree=False):
     """Spawn a headless Claude Code session and return tracking info.
 
     If `cwd` is provided, the spawned subprocess runs there; otherwise it
     inherits CCC's REPO_ROOT (backwards-compatible default).
+
+    If `worktree=True`, create a fresh git worktree off `cwd` (or
+    REPO_ROOT) on a `feat/<slug>` branch and run the spawned session
+    there. The worktree path + branch are returned in the response under
+    `worktree_path` / `worktree_branch` so the UI can show them.
     """
     # Always slugify — name may come from firstSentence(body) and contain
     # filesystem-hostile chars like quotes, colons, slashes.
@@ -4285,6 +4355,16 @@ def spawn_session(prompt, name=None, cwd=None):
     ]
 
     spawn_cwd = cwd if cwd else str(REPO_ROOT)
+    worktree_path = None
+    worktree_branch = None
+    if worktree:
+        try:
+            worktree_path, worktree_branch = _create_worktree_for_spawn(
+                spawn_cwd, session_name,
+            )
+            spawn_cwd = worktree_path
+        except RuntimeError as e:
+            return {"ok": False, "error": f"worktree creation failed: {e}"}
     log_fh = open(log_path, "w")
     fifo_path, child_stdin_fd = _make_stdin_fifo(log_path)
     popen_kwargs = dict(
@@ -4330,7 +4410,11 @@ def spawn_session(prompt, name=None, cwd=None):
         fifo=fifo_path,
     )
 
-    return {"ok": True, "pid": proc.pid, "name": session_name, "log": str(log_path)}
+    resp = {"ok": True, "pid": proc.pid, "name": session_name, "log": str(log_path)}
+    if worktree_path:
+        resp["worktree_path"] = worktree_path
+        resp["worktree_branch"] = worktree_branch
+    return resp
 
 
 _COLOR_PALETTE = [
@@ -8441,6 +8525,7 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
             name = (payload.get("name") or "").strip() or None
             cwd_raw = payload.get("cwd")
             cwd = cwd_raw.strip() if isinstance(cwd_raw, str) else None
+            worktree_flag = bool(payload.get("worktree"))
             if not prompt:
                 self.send_json({"ok": False, "error": "missing prompt"}, 400)
             elif cwd and not os.path.isabs(cwd):
@@ -8449,7 +8534,8 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
                 self.send_json({"ok": False, "error": f"cwd does not exist or is not a directory: {cwd}"}, 400)
             else:
                 try:
-                    self.send_json(spawn_session(prompt, name=name, cwd=cwd or None))
+                    self.send_json(spawn_session(prompt, name=name, cwd=cwd or None,
+                                                 worktree=worktree_flag))
                 except Exception as e:
                     self.send_json({"ok": False, "error": str(e)}, 500)
         elif re.match(r"^/api/sessions/spawned/\d+/inject$", path):

--- a/static/index.html
+++ b/static/index.html
@@ -2985,6 +2985,7 @@
         <button id="kptDescToggle" title="Compact mode — hide the description preview on cards" style="text-align:left;padding:6px 10px;background:transparent;border:none;color:var(--text);font-size:12px;cursor:pointer;border-radius:4px;">Compact</button>
         <button id="kptGitOnlyToggle" title="Show only cards linked to a GitHub issue" style="text-align:left;padding:6px 10px;background:transparent;border:none;color:var(--text);font-size:12px;cursor:pointer;border-radius:4px;">GitHub only</button>
         <label class="kpt-label" title="Spawn via Pkood (background agent runner) instead of headless Claude — see docs" style="display:flex;align-items:center;gap:6px;padding:6px 10px;font-size:12px;cursor:pointer;color:var(--text);"><input type="checkbox" id="kptPkoodToggle" style="margin:0;"> pkood spawn</label>
+        <label class="kpt-label" title="Spawn the new session in a fresh git worktree (`feat/<slug>` branch) so it can't accidentally commit to main" style="display:flex;align-items:center;gap:6px;padding:6px 10px;font-size:12px;cursor:pointer;color:var(--text);"><input type="checkbox" id="kptWorktreeToggle" style="margin:0;"> 🌿 worktree</label>
       </div>
     </div>
     <div id="setupBanner" class="ccc-setup-banner"></div>
@@ -3219,6 +3220,7 @@
       <textarea id="nsmBody" placeholder="What should this session do? (the first sentence becomes the card title — you can rename later or hit ✨ to AI-generate one)"></textarea>
       <div class="nsm-actions">
         <label class="nsm-pkood"><input type="checkbox" id="nsmPkood"> pkood</label>
+        <label class="nsm-pkood" title="Spawn the session in a fresh git worktree (`feat/<slug>` branch) so it can't accidentally commit to main."><input type="checkbox" id="nsmWorktree"> 🌿 worktree</label>
         <span style="flex:1;"></span>
         <button id="nsmCancel" class="nsm-btn">Cancel</button>
         <button id="nsmSubmit" class="nsm-btn nsm-primary">Launch</button>
@@ -10125,6 +10127,8 @@
       let prompt = ($kptNewSession && $kptNewSession.value || '').trim();
       if (!prompt) return;
       const usePkood = ($kptPkoodToggle && $kptPkoodToggle.checked) || prompt.startsWith('pkood:');
+      const $kptWorktreeToggle = document.getElementById('kptWorktreeToggle');
+      const useWorktree = !!($kptWorktreeToggle && $kptWorktreeToggle.checked);
       if (prompt.startsWith('pkood:')) prompt = prompt.slice(6).trim();
       if (!prompt) return;
       // Show the placeholder immediately — don't wait for the spawn POST to
@@ -10137,10 +10141,12 @@
       $kptRunBtn.textContent = 'Spawning...';
       try {
         const endpoint = usePkood ? '/api/pkood/spawn' : '/api/sessions/spawn';
+        // pkood doesn't support the worktree flag — silently drop it for that path.
+        const body = usePkood ? { prompt } : { prompt, worktree: useWorktree };
         const res = await fetch(endpoint, {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({ prompt }),
+          body: JSON.stringify(body),
         });
         const data = await res.json();
         if (data.ok) {
@@ -10197,6 +10203,9 @@
     _clearNsmError();
     $nsmBody.value = body || '';
     if ($nsmPkood && $kptPkoodToggle) $nsmPkood.checked = $kptPkoodToggle.checked;
+    const $nsmWorktree = document.getElementById('nsmWorktree');
+    const $kptWorktreeToggle = document.getElementById('kptWorktreeToggle');
+    if ($nsmWorktree && $kptWorktreeToggle) $nsmWorktree.checked = $kptWorktreeToggle.checked;
     $nsm.style.display = 'flex';
     setTimeout(() => { $nsmBody.focus(); }, 30);
   }
@@ -10216,13 +10225,18 @@
     const effectiveSubject = firstSentence(body);
     const prompt = body + SESSION_STATE_INSTRUCTION;
     const usePkood = !!($nsmPkood && $nsmPkood.checked);
+    const $nsmWorktree = document.getElementById('nsmWorktree');
+    const useWorktree = !!($nsmWorktree && $nsmWorktree.checked);
     $nsmSubmit.disabled = true;
     $nsmSubmit.textContent = 'Launching...';
     try {
       const endpoint = usePkood ? '/api/pkood/spawn' : '/api/sessions/spawn';
+      const body = usePkood
+        ? { prompt, name: effectiveSubject }
+        : { prompt, name: effectiveSubject, worktree: useWorktree };
       const res = await fetch(endpoint, {
         method: 'POST', headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ prompt, name: effectiveSubject }),
+        body: JSON.stringify(body),
       });
       const data = await res.json().catch(() => ({ ok: false, error: 'invalid JSON response' }));
       if (data.ok) {

--- a/static/index.html
+++ b/static/index.html
@@ -816,6 +816,11 @@
   .conv-input-context .wp-usage-clickable:hover { filter: brightness(1.2); }
   .conv-input-context .wp-usage-pct { opacity: 0.7; font-weight: 400; }
   .conv-input-context .wp-usage-peak { color: var(--text-muted); font-size: 10px; opacity: 0.7; }
+  .conv-input-context .wp-cost-pill {
+    padding: 2px 7px; border-radius: 3px; font-weight: 600;
+    color: var(--text-muted); background: rgba(139,148,158,0.06);
+    cursor: help;
+  }
   .conv-input-context .wp-ahead { color: var(--green); }
   .conv-input-context .wp-behind { color: var(--orange); }
   .conv-input-context .wp-even { color: var(--text-muted); opacity: 0.6; }
@@ -8742,10 +8747,27 @@
     const title = 'Latest assistant turn: ' + latest.toLocaleString() + ' tokens / '
       + limit.toLocaleString() + ' context limit' + overrideNote
       + ' (' + (u.model || 'model unknown') + ')\n\nClick to toggle between 200k and 1M.';
+    // Cost pill — Anthropic API list-price equivalent. Subscription users
+    // (Pro/Max) pay flat, but the figure is still the cleanest cross-model
+    // comparison of "how expensive was this session" so we surface it.
+    const cost = u.cost_usd || 0;
+    const breakdown = u.cost_breakdown_usd || {};
+    let costPill = '';
+    if (cost > 0) {
+      const fmt = (n) => n >= 1 ? '$' + n.toFixed(2) : '$' + n.toFixed(4);
+      const costTip = 'API list-price equivalent for ' + (u.model || 'unknown model') + '\n'
+        + '  Input:        ' + fmt(breakdown.input || 0) + '  (' + (u.total_input_tokens || 0).toLocaleString() + ' tok)\n'
+        + '  Cache write:  ' + fmt(breakdown.cache_creation || 0) + '  (' + (u.total_cache_creation_tokens || 0).toLocaleString() + ' tok)\n'
+        + '  Cache read:   ' + fmt(breakdown.cache_read || 0) + '  (' + (u.total_cache_read_tokens || 0).toLocaleString() + ' tok)\n'
+        + '  Output:       ' + fmt(breakdown.output || 0) + '  (' + (u.total_output_tokens || 0).toLocaleString() + ' tok)\n\n'
+        + 'Subscription users (Claude Pro/Max) pay flat — this is the\n'
+        + 'list-price equivalent if metered against the API directly.';
+      costPill = ' <span class="wp-cost-pill" title="' + escapeHtml(costTip) + '">' + fmt(cost) + '</span>';
+    }
     uSlot.innerHTML = '<span class="' + cls + '" title="' + escapeHtml(title) + '">'
       + 'ctx ' + _formatTokens(latest) + ' / ' + _formatTokens(limit)
       + ' <span class="wp-usage-pct">(' + pct + '%)</span>'
-      + '</span>' + peakNote;
+      + '</span>' + peakNote + costPill;
     slot.classList.add('visible');
     const pill = uSlot.querySelector('.wp-usage-clickable');
     if (pill) {


### PR DESCRIPTION
## Summary

Three competitor-adoption features for the conv pane and spawn flow, all developed in an isolated worktree (`feat/cost-notif-spawn`):

- **Cost-in-\$ pill** next to the existing `ctx` pill in the conv-input strip. Surfaces the Anthropic API list-price equivalent for the session's tokens; tooltip breaks out input / cache-write / cache-read / output by category. Useful for cross-model "how expensive was this session" comparisons even for subscription users (Claude Pro/Max pay flat — figure is informational).
- **Worktree-per-spawn checkbox** (`🌿 worktree`) added next to `pkood spawn` in both the inline new-session row and the new-session modal. When checked, the server runs `git worktree add ../<repo>-wt-<slug> -b feat/<slug>` against the source repo before launching the headless Claude — the agent literally cannot accidentally commit to main even if it ignores the multi-agent git-hygiene rules.
- **macOS native notifications** when Claude needs your attention. Stop hook fires "Ready for your input" banners, Notification hook fires "Claude needs your approval" with the prompt message inline. Default ON, opt-out via `CCC_NOTIFY=0`. Falls through silently on non-macOS systems.

Each feature is a separate commit so they can be reverted or cherry-picked independently. CHANGELOG entries dropped under `changelog.d/` per the per-snippet convention.

## Test plan

- [ ] **Cost pill** — Open the conv pane on any session with assistant turns. Verify the `\$X.XX` chip renders next to the ctx pill. Hover the chip → tooltip shows per-category breakdown (input / cache write / cache read / output) with token counts. For older sessions the "API list-price equivalent" copy should make sense; subscription users see the same number.
- [ ] **Worktree-per-spawn** — Open the new-session modal, check `🌿 worktree`, submit. Verify a new worktree dir appears at `<repo-parent>/<repo-name>-wt-<slug>` on a fresh `feat/<slug>` branch. Spawned session's workspace strip should show "worktree" rather than "shared clone". Repeat with the inline new-session row + Run button.
- [ ] **Path collisions** — Trigger a worktree spawn whose slug already has a worktree on disk. Verify the new path uses a numeric suffix (`...-wt-foo-2`) instead of failing.
- [ ] **macOS notifications** — `python3 -c "import sys, os; sys.path.insert(0, 'hooks'); import _notify; _notify.notify(title='CCC test', message='hello', subtitle='test')"` from the repo root. Banner should appear in macOS Notification Center. Test full path: send a follow-up to a live session, wait for it to finish — banner reads "Ready for your input". Trigger a permission prompt — banner reads "Claude needs your approval" with the message inline.
- [ ] **Notification opt-out** — `CCC_NOTIFY=0 ./run.sh`, verify no banners fire on Stop / Notification events.
- [ ] **Smoke** — `python3 tests/test_smoke.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)