### PR TITLE
feat(spawn): OpenAI Codex as a second spawn engine

### DIFF
--- a/changelog.d/added-codex-spawn-2026-04-30.md
+++ b/changelog.d/added-codex-spawn-2026-04-30.md
@@ -1,0 +1,22 @@
+**OpenAI Codex as a spawn engine.** The kanban toolbar now has an
+**Engine** dropdown (`claude` | `codex`) where the old `pkood spawn`
+checkbox used to live, and the new-session modal mirrors it.
+Selecting `codex` routes the next spawn through `codex exec --json
+--dangerously-bypass-approvals-and-sandbox` instead of `claude -p`,
+runs in the chosen working directory, and tracks the child on the
+same kanban with a green `codex` chip.
+
+Codex spawns are fire-and-watch in this iteration — no mid-run
+inject (Codex `exec` is one-shot), no `claude --resume`-style
+jump-in, and Codex JSONL ingestion isn't wired up yet. The
+selector greys out automatically when the Codex CLI binary
+can't be located (looked up via `$CCC_CODEX_BIN` →
+`which codex` → `/Applications/Codex.app/Contents/Resources/codex`).
+
+The `pkood:` prompt-prefix shortcut and `/api/pkood/spawn` endpoint
+are unchanged. New endpoints: `POST /api/sessions/spawn-codex`,
+`GET /api/sessions/spawn-codex/availability`. New env vars:
+`CCC_CODEX_BIN` (binary override), `CCC_CODEX_MODEL` (model name,
+default `gpt-5.5` — verified at release time against
+codex-cli 0.125.0-alpha.3; note that `gpt-5.5-codex` is rejected
+with a ChatGPT account).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-command-center"
-version = "0.2.1"
+version = "0.3.0"
 description = "A local command center for Claude Code that doesn't care how your agents were launched."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.py
+++ b/server.py
@@ -8339,6 +8339,10 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
             self.send_json(get_issue_details(num))
         elif path == "/api/sessions/spawned":
             self.send_json(list_spawned_sessions())
+        elif path == "/api/sessions/spawn-codex/availability":
+            info = _resolve_codex_bin()
+            info["model"] = os.environ.get("CCC_CODEX_MODEL", "gpt-5.5-codex")
+            self.send_json(info)
         elif path == "/api/sessions":
             self.send_json(find_all_sessions())
         elif path == "/api/conversations":

--- a/server.py
+++ b/server.py
@@ -4868,7 +4868,7 @@ def spawn_session_codex(prompt, name=None, cwd=None):
     log_path = LOG_DIR / log_filename
 
     spawn_cwd = cwd if cwd else str(REPO_ROOT)
-    model = os.environ.get("CCC_CODEX_MODEL", "gpt-5.5-codex")
+    model = os.environ.get("CCC_CODEX_MODEL", "gpt-5.5")
 
     cmd = [
         bin_path, "exec",
@@ -8344,7 +8344,7 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
             self.send_json(list_spawned_sessions())
         elif path == "/api/sessions/spawn-codex/availability":
             info = _resolve_codex_bin()
-            info["model"] = os.environ.get("CCC_CODEX_MODEL", "gpt-5.5-codex")
+            info["model"] = os.environ.get("CCC_CODEX_MODEL", "gpt-5.5")
             self.send_json(info)
         elif path == "/api/sessions":
             self.send_json(find_all_sessions())

--- a/server.py
+++ b/server.py
@@ -4282,11 +4282,14 @@ def find_all_sessions():
     registry = _load_session_registry()
     live_sids = set(registry.keys())
     spawned_pids = {s["pid"] for s in _spawned_sessions if s["proc"].poll() is None}
+    spawned_engine_by_pid = {s["pid"]: s.get("engine", "claude") for s in _spawned_sessions}
     for c in conversations:
         c["source"] = "interactive"
         c["is_live"] = c["session_id"] in live_sids
         reg_pid = (registry.get(c["session_id"]) or {}).get("pid")
         c["spawn_pid"] = reg_pid if reg_pid in spawned_pids else None
+        if c["spawn_pid"]:
+            c["engine"] = spawned_engine_by_pid.get(c["spawn_pid"], "claude")
 
     # Add pkood agents — and merge in their linked claude-session card, if any.
     # Pkood spawns a claude process in a tmux pty, which produces a regular

--- a/server.py
+++ b/server.py
@@ -4815,6 +4815,7 @@ def spawn_session(prompt, name=None, cwd=None, worktree=False):
         spawned_at=timestamp,
         command_summary=prompt[:200],
         fifo=fifo_path,
+        engine="claude",
     )
     # Cwd determines the ~/.claude/projects/ bucket the new session
     # logs to, which is how the kanban groups it by repo. Print it so
@@ -5168,6 +5169,7 @@ def resume_session_headless(session_id, text):
         spawned_at=timestamp,
         command_summary=text[:200],
         fifo=fifo_path,
+        engine="claude",
     )
     return {"ok": ok, "pid": proc.pid, "log": str(log_path), "resumed": True}
 
@@ -5244,12 +5246,16 @@ def _save_spawn_registry(entries):
         print(f"  [spawn-registry] could not write {SPAWNED_PIDS_FILE} ({e})")
 
 
-def _record_spawn_to_registry(pid, name, log_path, cwd, spawned_at, command_summary, fifo=None):
+def _record_spawn_to_registry(pid, name, log_path, cwd, spawned_at, command_summary, fifo=None, engine="claude"):
     """Append a freshly-spawned session to the on-disk registry. The
     session_id is filled in lazily by the reattach sweep (it isn't known
-    at fork time — Claude emits it in the first stream-json event).
+    at fork time — Claude emits it in the first stream-json event, Codex
+    emits it in its `--json` event stream).
     The fifo path is persisted so a fresh CCC instance can reopen the
-    write side after a restart and continue injecting messages."""
+    write side after a restart and continue injecting messages (Claude
+    only — Codex exec is one-shot).
+    `engine` ("claude" or "codex") tells the boot-time reattach sweep
+    which ps-grep to use and which JSONL ingestion path to skip."""
     entries = _load_spawn_registry()
     entries.append({
         "pid": pid,
@@ -5260,6 +5266,7 @@ def _record_spawn_to_registry(pid, name, log_path, cwd, spawned_at, command_summ
         "cwd": str(cwd),
         "spawned_at": spawned_at,
         "command_summary": command_summary,
+        "engine": engine,
     })
     _save_spawn_registry(entries)
 
@@ -5273,13 +5280,19 @@ def _remove_spawn_from_registry(pid):
         _save_spawn_registry(pruned)
 
 
-def _pid_is_claude_process(pid):
-    """Verify a PID is actually a `claude` process before treating it as one
-    of ours. PIDs get reused, so a bare `os.kill(pid, 0)` isn't enough — we
-    could end up trying to inject into someone's vim. Uses `ps -p <pid> -o
-    command=` (works on macOS + Linux) and matches strictly on argv[0]
-    basename — substring matching is too lenient (any python process whose
-    argv mentions 'claude' would otherwise pass)."""
+def _pid_is_engine_process(pid, engine):
+    """Verify a PID is actually a process for the given engine before
+    treating it as one of ours. PIDs get reused, so a bare `os.kill(pid, 0)`
+    isn't enough — we could end up trying to inject into someone's vim.
+    Uses `ps -p <pid> -o command=` (works on macOS + Linux) and matches
+    strictly on argv[0] basename — substring matching is too lenient
+    (any python process whose argv mentions 'claude' would otherwise
+    pass).
+
+    `engine` is one of "claude" or "codex" — the basename we expect at
+    argv[0]."""
+    if engine not in ("claude", "codex"):
+        return False
     try:
         out = subprocess.run(
             ["ps", "-p", str(pid), "-o", "command="],
@@ -5295,9 +5308,14 @@ def _pid_is_claude_process(pid):
     parts = cmd.split()
     if not parts:
         return False
-    # Match the executable basename only; `claude -p ...` shows up as
-    # `/path/to/claude -p ...` on macOS or just `claude -p ...` on Linux.
-    return parts[0].rsplit("/", 1)[-1] == "claude"
+    return parts[0].rsplit("/", 1)[-1] == engine
+
+
+# Backwards-compat shim — older code paths (and any out-of-tree fork)
+# that imports the old name keeps working without edits. Always asks
+# the engine-aware version with engine="claude".
+def _pid_is_claude_process(pid):
+    return _pid_is_engine_process(pid, "claude")
 
 
 def _reattach_spawned_orphans():
@@ -5335,15 +5353,21 @@ def _reattach_spawned_orphans():
         if not alive:
             dropped += 1
             continue
-        # Step 2: is it actually a claude process? (PID reuse defence.)
-        if not _pid_is_claude_process(pid):
+        # Step 2: is it actually a process of the engine we recorded?
+        # Older registry entries pre-date the `engine` field — default
+        # them to "claude" since that's all CCC spawned before Codex
+        # support landed. PID reuse defence.
+        engine = entry.get("engine", "claude")
+        if not _pid_is_engine_process(pid, engine):
             dropped += 1
             continue
         # Step 3: try to backfill session_id from the log file if we don't
-        # have it yet. Best-effort — failures don't block reattach.
+        # have it yet. Claude logs only — Codex's JSONL event shape
+        # differs and ingestion is deferred to a later iteration.
+        # Best-effort — failures don't block reattach.
         session_id = entry.get("session_id")
         log_path = entry.get("log")
-        if not session_id and log_path:
+        if engine == "claude" and not session_id and log_path:
             try:
                 session_id = extract_session_id(log_path)
             except Exception:
@@ -5367,6 +5391,7 @@ def _reattach_spawned_orphans():
             "fifo": fifo_path,
             "stdin_fd": stdin_fd,
             "reattached": True,
+            "engine": engine,
         }
         if session_id:
             synthetic["resumed_sid"] = session_id
@@ -5380,6 +5405,7 @@ def _reattach_spawned_orphans():
             "cwd": entry.get("cwd"),
             "spawned_at": entry.get("spawned_at"),
             "command_summary": entry.get("command_summary", ""),
+            "engine": engine,
         })
         reattached += 1
 

--- a/server.py
+++ b/server.py
@@ -4687,12 +4687,8 @@ def _create_worktree_for_spawn(source_cwd, slug):
 # ---------------------------------------------------------------------------
 # Codex CLI binary resolution
 # ---------------------------------------------------------------------------
-#
-# Tested against codex-cli 0.125.0-alpha.3 (the version bundled inside
-# /Applications/Codex.app on the dev machine that shipped this feature).
-# Flag names may shift in future alpha bumps — if a smoke spawn fails with
-# "unrecognized argument", check `<bin> exec --help` and patch the cmd
-# construction in spawn_session_codex below.
+# Tested against codex-cli 0.125.0-alpha.3, the version currently shipping
+# inside /Applications/Codex.app.
 
 CODEX_APP_BUNDLE_PATH = "/Applications/Codex.app/Contents/Resources/codex"
 

--- a/server.py
+++ b/server.py
@@ -4684,6 +4684,57 @@ def _create_worktree_for_spawn(source_cwd, slug):
     return str(candidate), branch
 
 
+# ---------------------------------------------------------------------------
+# Codex CLI binary resolution
+# ---------------------------------------------------------------------------
+#
+# Tested against codex-cli 0.125.0-alpha.3 (the version bundled inside
+# /Applications/Codex.app on the dev machine that shipped this feature).
+# Flag names may shift in future alpha bumps — if a smoke spawn fails with
+# "unrecognized argument", check `<bin> exec --help` and patch the cmd
+# construction in spawn_session_codex below.
+
+CODEX_APP_BUNDLE_PATH = "/Applications/Codex.app/Contents/Resources/codex"
+
+
+def _resolve_codex_bin():
+    """Locate a usable Codex CLI binary.
+
+    Priority order:
+      1. $CCC_CODEX_BIN (env override) — if set and executable.
+      2. `shutil.which("codex")` — picks up Homebrew / Cargo / npm-global.
+      3. /Applications/Codex.app/Contents/Resources/codex (macOS Codex
+         desktop app's bundled CLI).
+
+    Returns a dict so the caller and the availability endpoint can share
+    one shape:
+      {available: True,  bin: "<abs path>", source: "env|path|bundle"}
+      {available: False, reason: "<human readable>", bin: None}
+    """
+    env_bin = os.environ.get("CCC_CODEX_BIN")
+    if env_bin:
+        if os.path.isfile(env_bin) and os.access(env_bin, os.X_OK):
+            return {"available": True, "bin": env_bin, "source": "env"}
+        return {
+            "available": False,
+            "bin": None,
+            "reason": f"CCC_CODEX_BIN is set to {env_bin!r} but it isn't an executable file",
+        }
+    which_bin = shutil.which("codex")
+    if which_bin:
+        return {"available": True, "bin": which_bin, "source": "path"}
+    if os.path.isfile(CODEX_APP_BUNDLE_PATH) and os.access(CODEX_APP_BUNDLE_PATH, os.X_OK):
+        return {"available": True, "bin": CODEX_APP_BUNDLE_PATH, "source": "bundle"}
+    return {
+        "available": False,
+        "bin": None,
+        "reason": (
+            "Codex CLI not found. Install Codex.app, "
+            "`npm i -g @openai/codex`, or set CCC_CODEX_BIN."
+        ),
+    }
+
+
 def spawn_session(prompt, name=None, cwd=None, worktree=False):
     """Spawn a headless Claude Code session and return tracking info.
 

--- a/server.py
+++ b/server.py
@@ -12,7 +12,7 @@ Usage:
     CCC_WATCH_REPO=~/dev/foo ./run.sh
 """
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 import ast
 import base64

--- a/server.py
+++ b/server.py
@@ -9322,6 +9322,35 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
                     ))
                 except Exception as e:
                     self.send_json({"ok": False, "error": str(e)}, 500)
+        elif path == "/api/sessions/spawn-codex":
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length) if length > 0 else b""
+            try:
+                payload = json.loads(body) if body else {}
+            except json.JSONDecodeError:
+                payload = {}
+            prompt = (payload.get("prompt") or "").strip()
+            name = (payload.get("name") or "").strip() or None
+            cwd_raw = payload.get("cwd")
+            cwd = cwd_raw.strip() if isinstance(cwd_raw, str) else None
+            if not prompt:
+                self.send_json({"ok": False, "error": "missing prompt"}, 400)
+            elif cwd and not os.path.isabs(cwd):
+                self.send_json({"ok": False, "error": f"cwd must be an absolute path: {cwd}"}, 400)
+            elif cwd and not os.path.isdir(cwd):
+                self.send_json({"ok": False, "error": f"cwd does not exist or is not a directory: {cwd}"}, 400)
+            else:
+                try:
+                    result = spawn_session_codex(prompt, name=name, cwd=cwd or None)
+                    # Resolver missing-binary failures get a 503 so the
+                    # frontend can distinguish them from generic 500s and
+                    # offer the install hint without parsing the body.
+                    if not result.get("ok") and "not found" in (result.get("error") or "").lower():
+                        self.send_json(result, 503)
+                    else:
+                        self.send_json(result)
+                except Exception as e:
+                    self.send_json({"ok": False, "error": str(e)}, 500)
         elif re.match(r"^/api/sessions/spawned/\d+/inject$", path):
             pid = int(path.split("/")[4])
             length = int(self.headers.get("Content-Length", "0"))

--- a/server.py
+++ b/server.py
@@ -4828,6 +4828,90 @@ def spawn_session(prompt, name=None, cwd=None, worktree=False):
     return resp
 
 
+def spawn_session_codex(prompt, name=None, cwd=None):
+    """Spawn a headless Codex CLI run and return tracking info.
+
+    Mirrors `spawn_session` but invokes the Codex CLI's `exec`
+    subcommand instead of `claude -p`. Codex `exec` is one-shot —
+    the prompt comes from argv and the process exits when the model
+    is done — so we use `subprocess.DEVNULL` for stdin (no FIFO,
+    no mid-run inject support).
+
+    Tested against codex-cli 0.125.0-alpha.3.
+
+    If `cwd` is provided, the spawned subprocess runs there AND the
+    Codex `--cd` flag is set so the agent's workspace root matches
+    the launch directory. Otherwise we inherit CCC's REPO_ROOT
+    (backwards-compatible default).
+
+    Returns the same shape as spawn_session:
+      {ok: True,  pid, name, log}                       — success
+      {ok: False, error}                                — resolver failed
+    """
+    resolved = _resolve_codex_bin()
+    if not resolved["available"]:
+        return {"ok": False, "error": resolved["reason"]}
+    bin_path = resolved["bin"]
+
+    session_name = _slugify(name or prompt)
+    if not session_name:
+        session_name = "unnamed"
+    timestamp = time.strftime("%Y%m%dT%H%M%S")
+    log_filename = f"spawn-codex-{session_name}-{timestamp}.log"
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    log_path = LOG_DIR / log_filename
+
+    spawn_cwd = cwd if cwd else str(REPO_ROOT)
+    model = os.environ.get("CCC_CODEX_MODEL", "gpt-5.5-codex")
+
+    cmd = [
+        bin_path, "exec",
+        "--json",
+        "--skip-git-repo-check",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--model", model,
+        "--cd", spawn_cwd,
+        "--",
+        prompt,
+    ]
+
+    log_fh = open(log_path, "w")
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=log_fh,
+        stderr=subprocess.STDOUT,
+        cwd=spawn_cwd,
+        start_new_session=True,
+    )
+
+    entry = {
+        "pid": proc.pid,
+        "name": session_name,
+        "log": str(log_path),
+        "prompt": prompt[:200],
+        "started": timestamp,
+        "proc": proc,
+        "log_fh": log_fh,
+        "fifo": None,         # Codex exec is one-shot; no inject FIFO.
+        "stdin_fd": None,
+        "engine": "codex",
+    }
+    _spawned_sessions.append(entry)
+    _record_spawn_to_registry(
+        pid=proc.pid,
+        name=session_name,
+        log_path=log_path,
+        cwd=spawn_cwd,
+        spawned_at=timestamp,
+        command_summary=prompt[:200],
+        fifo=None,
+        engine="codex",
+    )
+
+    return {"ok": True, "pid": proc.pid, "name": session_name, "log": str(log_path)}
+
+
 _COLOR_PALETTE = [
     "red", "orange", "yellow", "green", "cyan", "blue", "purple", "magenta", "pink",
 ]

--- a/server.py
+++ b/server.py
@@ -4714,6 +4714,7 @@ def _resolve_codex_bin():
         return {
             "available": False,
             "bin": None,
+            "code": "codex_unavailable",
             "reason": f"CCC_CODEX_BIN is set to {env_bin!r} but it isn't an executable file",
         }
     which_bin = shutil.which("codex")
@@ -4724,6 +4725,7 @@ def _resolve_codex_bin():
     return {
         "available": False,
         "bin": None,
+        "code": "codex_unavailable",
         "reason": (
             "Codex CLI not found. Install Codex.app, "
             "`npm i -g @openai/codex`, or set CCC_CODEX_BIN."
@@ -4851,7 +4853,7 @@ def spawn_session_codex(prompt, name=None, cwd=None):
     """
     resolved = _resolve_codex_bin()
     if not resolved["available"]:
-        return {"ok": False, "error": resolved["reason"]}
+        return {"ok": False, "error": resolved["reason"], "code": resolved.get("code")}
     bin_path = resolved["bin"]
 
     session_name = _slugify(name or prompt)
@@ -9337,15 +9339,18 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
                 self.send_json({"ok": False, "error": "missing prompt"}, 400)
             elif cwd and not os.path.isabs(cwd):
                 self.send_json({"ok": False, "error": f"cwd must be an absolute path: {cwd}"}, 400)
+            elif cwd and not os.path.exists(cwd):
+                self.send_json({"ok": False, "error": f"cwd does not exist: {cwd}"}, 400)
             elif cwd and not os.path.isdir(cwd):
-                self.send_json({"ok": False, "error": f"cwd does not exist or is not a directory: {cwd}"}, 400)
+                self.send_json({"ok": False, "error": f"cwd is not a directory: {cwd}"}, 400)
             else:
                 try:
-                    result = spawn_session_codex(prompt, name=name, cwd=cwd or None)
-                    # Resolver missing-binary failures get a 503 so the
-                    # frontend can distinguish them from generic 500s and
-                    # offer the install hint without parsing the body.
-                    if not result.get("ok") and "not found" in (result.get("error") or "").lower():
+                    result = spawn_session_codex(prompt, name=name, cwd=cwd)
+                    # Resolver-side failures (binary not found, CCC_CODEX_BIN
+                    # misconfigured) carry a stable `"code": "codex_unavailable"`
+                    # so the frontend can render an install hint without
+                    # parsing the human-readable error text.
+                    if result.get("code") == "codex_unavailable":
                         self.send_json(result, 503)
                     else:
                         self.send_json(result)

--- a/server.py
+++ b/server.py
@@ -5286,7 +5286,7 @@ def _pid_is_engine_process(pid, engine):
     isn't enough — we could end up trying to inject into someone's vim.
     Uses `ps -p <pid> -o command=` (works on macOS + Linux) and matches
     strictly on argv[0] basename — substring matching is too lenient
-    (any python process whose argv mentions 'claude' would otherwise
+    (any python process whose argv mentions the engine name would otherwise
     pass).
 
     `engine` is one of "claude" or "codex" — the basename we expect at
@@ -5311,17 +5311,10 @@ def _pid_is_engine_process(pid, engine):
     return parts[0].rsplit("/", 1)[-1] == engine
 
 
-# Backwards-compat shim — older code paths (and any out-of-tree fork)
-# that imports the old name keeps working without edits. Always asks
-# the engine-aware version with engine="claude".
-def _pid_is_claude_process(pid):
-    return _pid_is_engine_process(pid, "claude")
-
-
 def _reattach_spawned_orphans():
     """Boot-time sweep that re-populates `_spawned_sessions` from the on-disk
-    registry. Verifies every entry's PID is alive AND is still a `claude`
-    process (PIDs can be reused), drops dead/reused ones, and rewrites the
+    registry. Verifies every entry's PID is alive AND is still a process of
+    the recorded engine (PIDs can be reused), drops dead/reused ones, and rewrites the
     registry. Never kills anything — just makes live orphans visible to the
     dashboard again."""
     raw_entries = _load_spawn_registry()

--- a/server.py
+++ b/server.py
@@ -9341,18 +9341,38 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
             prompt = (payload.get("prompt") or "").strip()
             name = (payload.get("name") or "").strip() or None
             cwd_raw = payload.get("cwd")
-            cwd = cwd_raw.strip() if isinstance(cwd_raw, str) else None
+            cwd_input = cwd_raw.strip() if isinstance(cwd_raw, str) else ""
+            cwd_resolved = None
+            cwd_error = None
+            if cwd_input:
+                try:
+                    expanded = os.path.expanduser(cwd_input)
+                    candidate = Path(expanded).resolve()
+                except (OSError, RuntimeError) as e:
+                    cwd_error = f"could not resolve path ({e})"
+                else:
+                    home = Path.home().resolve()
+                    try:
+                        st = os.stat(candidate)
+                    except OSError as e:
+                        cwd_error = f"path does not exist ({e.strerror or e})"
+                    else:
+                        if not stat.S_ISDIR(st.st_mode):
+                            cwd_error = f"not a directory: {candidate}"
+                        else:
+                            try:
+                                candidate.relative_to(home)
+                            except ValueError:
+                                cwd_error = f"path is outside $HOME ({home}): {candidate}"
+                            else:
+                                cwd_resolved = candidate
             if not prompt:
                 self.send_json({"ok": False, "error": "missing prompt"}, 400)
-            elif cwd and not os.path.isabs(cwd):
-                self.send_json({"ok": False, "error": f"cwd must be an absolute path: {cwd}"}, 400)
-            elif cwd and not os.path.exists(cwd):
-                self.send_json({"ok": False, "error": f"cwd does not exist: {cwd}"}, 400)
-            elif cwd and not os.path.isdir(cwd):
-                self.send_json({"ok": False, "error": f"cwd is not a directory: {cwd}"}, 400)
+            elif cwd_error:
+                self.send_json({"ok": False, "error": f"invalid cwd: {cwd_error}"}, 400)
             else:
                 try:
-                    result = spawn_session_codex(prompt, name=name, cwd=cwd)
+                    result = spawn_session_codex(prompt, name=name, cwd=str(cwd_resolved) if cwd_resolved else None)
                     # Resolver-side failures (binary not found, CCC_CODEX_BIN
                     # misconfigured) carry a stable `"code": "codex_unavailable"`
                     # so the frontend can render an install hint without

--- a/static/index.html
+++ b/static/index.html
@@ -2758,7 +2758,7 @@
     .kanban-panel-toolbar .kpt-new-session,
     .kanban-panel-toolbar #kptRunBtn,
     .kanban-panel-toolbar #kptRecentBtn,
-    .kanban-panel-toolbar #kptPkoodToggle,
+    .kanban-panel-toolbar #kptEngineSelect,
     .kanban-panel-toolbar #kptGitOnlyToggle,
     .kanban-panel-toolbar #kptDescToggle,
     .kanban-panel-toolbar .kpt-label,
@@ -3132,7 +3132,13 @@
         <button id="kptRecentBtn" title="Show only sessions/issues touched in the last 10 hours" style="text-align:left;padding:6px 10px;background:transparent;border:none;color:var(--text);font-size:12px;cursor:pointer;border-radius:4px;">Last 10h</button>
         <button id="kptDescToggle" title="Compact mode — hide the description preview on cards" style="text-align:left;padding:6px 10px;background:transparent;border:none;color:var(--text);font-size:12px;cursor:pointer;border-radius:4px;">Compact</button>
         <button id="kptGitOnlyToggle" title="Show only cards linked to a GitHub issue" style="text-align:left;padding:6px 10px;background:transparent;border:none;color:var(--text);font-size:12px;cursor:pointer;border-radius:4px;">GitHub only</button>
-        <label class="kpt-label" title="Spawn via Pkood (background agent runner) instead of headless Claude — see docs" style="display:flex;align-items:center;gap:6px;padding:6px 10px;font-size:12px;cursor:pointer;color:var(--text);"><input type="checkbox" id="kptPkoodToggle" style="margin:0;"> pkood spawn</label>
+        <label class="kpt-label" title="Pick which engine spawns the next session — Claude (default) or OpenAI Codex" style="display:flex;align-items:center;gap:6px;padding:6px 10px;font-size:12px;cursor:pointer;color:var(--text);">
+          Engine
+          <select id="kptEngineSelect" style="background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:2px 6px;font-size:12px;">
+            <option value="claude">claude</option>
+            <option value="codex">codex</option>
+          </select>
+        </label>
         <label class="kpt-label" title="Spawn the new session in a fresh git worktree (`feat/<slug>` branch) so it can't accidentally commit to main" style="display:flex;align-items:center;gap:6px;padding:6px 10px;font-size:12px;cursor:pointer;color:var(--text);"><input type="checkbox" id="kptWorktreeToggle" style="margin:0;"> 🌿 worktree</label>
       </div>
     </div>
@@ -10538,7 +10544,23 @@
   const $kptSearch = document.getElementById('kptSearch');
   const $kptRefreshBtn = document.getElementById('kptRefreshBtn');
   const $kptRecentBtn = document.getElementById('kptRecentBtn');
-  const $kptPkoodToggle = document.getElementById('kptPkoodToggle');
+  // Legacy reference kept so dispatcher branches that read $kptPkoodToggle
+  // (rewritten in Task 8 of the codex-spawn series) don't crash. Always
+  // null — pkood spawning still works via the `pkood:` prompt prefix.
+  let $kptPkoodToggle = null;
+
+  const $kptEngineSelect = document.getElementById('kptEngineSelect');
+  // Restore last-used engine from localStorage so the user's choice
+  // persists across reloads. Defaults to 'claude' on first launch.
+  if ($kptEngineSelect) {
+    try {
+      const saved = localStorage.getItem('ccc.spawnEngine');
+      if (saved === 'claude' || saved === 'codex') $kptEngineSelect.value = saved;
+    } catch (_) {}
+    $kptEngineSelect.addEventListener('change', () => {
+      try { localStorage.setItem('ccc.spawnEngine', $kptEngineSelect.value); } catch (_) {}
+    });
+  }
   // Hide-descriptions toggle
   const $kptDescToggle = document.getElementById('kptDescToggle');
   if ($kptDescToggle) {

--- a/static/index.html
+++ b/static/index.html
@@ -3370,7 +3370,13 @@
       </div>
       <textarea id="nsmBody" placeholder="What should this session do? (the first sentence becomes the card title — you can rename later or hit ✨ to AI-generate one)"></textarea>
       <div class="nsm-actions">
-        <label class="nsm-pkood"><input type="checkbox" id="nsmPkood"> pkood</label>
+        <label class="nsm-engine" style="display:flex;align-items:center;gap:6px;font-size:12px;color:var(--text);">
+          Engine
+          <select id="nsmEngineSelect" style="background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:2px 6px;font-size:12px;">
+            <option value="claude">claude</option>
+            <option value="codex">codex</option>
+          </select>
+        </label>
         <label class="nsm-pkood" title="Spawn the session in a fresh git worktree (`feat/<slug>` branch) so it can't accidentally commit to main."><input type="checkbox" id="nsmWorktree"> 🌿 worktree</label>
         <span style="flex:1;"></span>
         <button id="nsmCancel" class="nsm-btn">Cancel</button>
@@ -10821,12 +10827,21 @@
   const $nsmSubmit = document.getElementById('nsmSubmit');
   const $nsmCancel = document.getElementById('nsmCancel');
   const $nsmBackdrop = document.getElementById('nsmBackdrop');
-  const $nsmPkood = document.getElementById('nsmPkood');
+  const $nsmEngineSelect = document.getElementById('nsmEngineSelect');
+  // Legacy reference: kept null so the modal-submit dispatcher
+  // (rewritten in Task 8 of the codex-spawn series) doesn't crash
+  // when it reads `$nsmPkood.checked` before that rewrite lands.
+  let $nsmPkood = null;
   function openNewSessionModal(body = '') {
     if (!$nsm) return;
     _clearNsmError();
     $nsmBody.value = body || '';
-    if ($nsmPkood && $kptPkoodToggle) $nsmPkood.checked = $kptPkoodToggle.checked;
+    // Sync from the toolbar selector so the modal opens on the same
+    // engine the user just picked. Falls back to 'claude' if the
+    // toolbar element is missing (defensive — both should always exist).
+    if ($nsmEngineSelect && $kptEngineSelect) {
+      $nsmEngineSelect.value = $kptEngineSelect.value || 'claude';
+    }
     const $nsmWorktree = document.getElementById('nsmWorktree');
     const $kptWorktreeToggle = document.getElementById('kptWorktreeToggle');
     if ($nsmWorktree && $kptWorktreeToggle) $nsmWorktree.checked = $kptWorktreeToggle.checked;

--- a/static/index.html
+++ b/static/index.html
@@ -3711,7 +3711,7 @@
     // feature itself; keeping it visible nudges users to `vercel link`.
     const $kptDeploy = document.getElementById('kptDeployStatus');
     if ($kptDeploy && !APP_CONFIG.vercel_enabled) $kptDeploy.style.display = 'none';
-    document.querySelectorAll('.pkood-toggle-label, .kpt-label, .nsm-pkood').forEach(el => {
+    document.querySelectorAll('.pkood-toggle-label').forEach(el => {
       if (!APP_CONFIG.pkood_enabled) el.style.display = 'none';
     });
     if (APP_CONFIG.repo) document.body.dataset.repo = APP_CONFIG.repo;

--- a/static/index.html
+++ b/static/index.html
@@ -10572,6 +10572,35 @@
       try { localStorage.setItem('ccc.spawnEngine', $kptEngineSelect.value); } catch (_) {}
     });
   }
+  // Probe Codex availability so a user with no Codex install sees the
+  // option greyed out instead of getting a 503 mid-spawn. Polled on
+  // window focus too — handles "I just installed it; refresh the UI"
+  // without a hard reload.
+  async function refreshCodexAvailability() {
+    try {
+      const r = await fetch('/api/sessions/spawn-codex/availability');
+      const d = await r.json();
+      const codexOpt = $kptEngineSelect && $kptEngineSelect.querySelector('option[value="codex"]');
+      const nsmCodexOpt = (typeof $nsmEngineSelect !== 'undefined') && $nsmEngineSelect && $nsmEngineSelect.querySelector('option[value="codex"]');
+      const reason = d.available ? '' : (d.reason || 'Codex CLI not found');
+      [codexOpt, nsmCodexOpt].forEach(opt => {
+        if (!opt) return;
+        opt.disabled = !d.available;
+        opt.title = reason;
+        opt.textContent = d.available ? 'codex' : 'codex (unavailable)';
+      });
+      // If the user had codex selected but it's no longer available,
+      // fall back to claude so the next spawn doesn't 503.
+      if (!d.available && $kptEngineSelect && $kptEngineSelect.value === 'codex') {
+        $kptEngineSelect.value = 'claude';
+        try { localStorage.setItem('ccc.spawnEngine', 'claude'); } catch (_) {}
+      }
+    } catch (_) {
+      // Probe is best-effort; a network blip shouldn't disable the dropdown.
+    }
+  }
+  refreshCodexAvailability();
+  window.addEventListener('focus', refreshCodexAvailability);
   // Hide-descriptions toggle
   const $kptDescToggle = document.getElementById('kptDescToggle');
   if ($kptDescToggle) {

--- a/static/index.html
+++ b/static/index.html
@@ -5137,14 +5137,22 @@
   // Pending spawn placeholders (optimistic UI) — keyed by pid.
   const pendingSpawns = new Map();
 
-  function insertPendingSpawnCard(pid, subject, usePkood) {
+  function insertPendingSpawnCard(pid, subject, sourceOrEngine) {
     if (!pid) return;
     const id = 'spawning-' + pid;
+    // Backwards-compat: this used to take `usePkood: bool`. Accept
+    // either the legacy boolean (true → 'pkood') or a new explicit
+    // string ('claude' | 'codex' | 'pkood' | 'interactive').
+    let source;
+    if (sourceOrEngine === true) source = 'pkood';
+    else if (sourceOrEngine === false || sourceOrEngine == null) source = 'interactive';
+    else if (typeof sourceOrEngine === 'string') source = sourceOrEngine;
+    else source = 'interactive';
     const card = {
       id, session_id: id,
       display_name: subject || ('Spawning #' + pid),
       first_message: '',
-      source: usePkood ? 'pkood' : 'interactive',
+      source,
       is_live: true, archived: false, verified: false,
       spawn_pid: pid, pending_spawn: true,
       has_edit: false, has_commit: false, has_push: false,
@@ -10550,11 +10558,6 @@
   const $kptSearch = document.getElementById('kptSearch');
   const $kptRefreshBtn = document.getElementById('kptRefreshBtn');
   const $kptRecentBtn = document.getElementById('kptRecentBtn');
-  // Legacy reference kept so dispatcher branches that read $kptPkoodToggle
-  // (rewritten in Task 8 of the codex-spawn series) don't crash. Always
-  // null — pkood spawning still works via the `pkood:` prompt prefix.
-  let $kptPkoodToggle = null;
-
   const $kptEngineSelect = document.getElementById('kptEngineSelect');
   // Restore last-used engine from localStorage so the user's choice
   // persists across reloads. Defaults to 'claude' on first launch.
@@ -10756,23 +10759,36 @@
     $kptRunBtn.addEventListener('click', async () => {
       let prompt = ($kptNewSession && $kptNewSession.value || '').trim();
       if (!prompt) return;
-      const usePkood = ($kptPkoodToggle && $kptPkoodToggle.checked) || prompt.startsWith('pkood:');
+      const isPkoodPrefix = prompt.startsWith('pkood:');
+      const engine = isPkoodPrefix
+        ? 'pkood'
+        : (($kptEngineSelect && $kptEngineSelect.value) || 'claude');
       const $kptWorktreeToggle = document.getElementById('kptWorktreeToggle');
       const useWorktree = !!($kptWorktreeToggle && $kptWorktreeToggle.checked);
-      if (prompt.startsWith('pkood:')) prompt = prompt.slice(6).trim();
+      if (isPkoodPrefix) prompt = prompt.slice(6).trim();
       if (!prompt) return;
       // Show the placeholder immediately — don't wait for the spawn POST to
       // return. Users were staring at a blank board for a beat because the
       // placeholder only materialized after /api/sessions/spawn responded.
       const subject = prompt.length > 60 ? prompt.slice(0, 60) + '…' : prompt;
       const tempPid = 'tmp-' + Date.now();
-      insertPendingSpawnCard(tempPid, subject, usePkood);
+      // Source for the optimistic card: 'codex' renders the codex chip
+      // (Task 9); 'pkood' keeps the orange pkood chip; 'claude' uses
+      // 'interactive' (no chip).
+      const cardSource = engine === 'codex' ? 'codex'
+                       : engine === 'pkood' ? 'pkood'
+                       : 'interactive';
+      insertPendingSpawnCard(tempPid, subject, cardSource);
       $kptRunBtn.disabled = true;
       $kptRunBtn.textContent = 'Spawning...';
       try {
-        const endpoint = usePkood ? '/api/pkood/spawn' : '/api/sessions/spawn';
-        // pkood doesn't support the worktree flag — silently drop it for that path.
-        const body = usePkood ? { prompt } : { prompt, worktree: useWorktree };
+        const endpoint = engine === 'pkood' ? '/api/pkood/spawn'
+                       : engine === 'codex' ? '/api/sessions/spawn-codex'
+                       : '/api/sessions/spawn';
+        // pkood and codex don't support the worktree flag — drop it for those.
+        const body = engine === 'claude'
+          ? { prompt, worktree: useWorktree }
+          : { prompt };
         const res = await fetch(endpoint, {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
@@ -10828,10 +10844,6 @@
   const $nsmCancel = document.getElementById('nsmCancel');
   const $nsmBackdrop = document.getElementById('nsmBackdrop');
   const $nsmEngineSelect = document.getElementById('nsmEngineSelect');
-  // Legacy reference: kept null so the modal-submit dispatcher
-  // (rewritten in Task 8 of the codex-spawn series) doesn't crash
-  // when it reads `$nsmPkood.checked` before that rewrite lands.
-  let $nsmPkood = null;
   function openNewSessionModal(body = '') {
     if (!$nsm) return;
     _clearNsmError();
@@ -10863,14 +10875,15 @@
     }
     const effectiveSubject = firstSentence(body);
     const prompt = body + SESSION_STATE_INSTRUCTION;
-    const usePkood = !!($nsmPkood && $nsmPkood.checked);
+    const engine = ($nsmEngineSelect && $nsmEngineSelect.value) || 'claude';
     const $nsmWorktree = document.getElementById('nsmWorktree');
     const useWorktree = !!($nsmWorktree && $nsmWorktree.checked);
     $nsmSubmit.disabled = true;
     $nsmSubmit.textContent = 'Launching...';
     try {
-      const endpoint = usePkood ? '/api/pkood/spawn' : '/api/sessions/spawn';
-      const body = usePkood
+      const endpoint = engine === 'codex' ? '/api/sessions/spawn-codex'
+                                          : '/api/sessions/spawn';
+      const body = engine === 'codex'
         ? { prompt, name: effectiveSubject }
         : { prompt, name: effectiveSubject, worktree: useWorktree };
       const res = await fetch(endpoint, {
@@ -10880,7 +10893,8 @@
       const data = await res.json().catch(() => ({ ok: false, error: 'invalid JSON response' }));
       if (data.ok) {
         closeNewSessionModal();
-        insertPendingSpawnCard(data.pid, effectiveSubject, usePkood);
+        const cardSource = engine === 'codex' ? 'codex' : 'interactive';
+        insertPendingSpawnCard(data.pid, effectiveSubject, cardSource);
         // Tight poll schedule so the real card replaces the placeholder fast.
         setTimeout(refreshConversationList, 600);
         setTimeout(refreshConversationList, 1500);

--- a/static/index.html
+++ b/static/index.html
@@ -1410,6 +1410,7 @@
    * same row. */
   .conv-signal.gh-link { background: rgba(139,148,158,0.12); color: var(--text-muted); font-weight: 600; }
   .conv-item .source-badge.pkood { background: rgba(210,153,34,0.2); color: var(--orange); }
+  .conv-item .source-badge.codex { background: rgba(63,185,80,0.2); color: var(--green); }
   .pkood-tail-output {
     white-space: pre-wrap; word-break: break-word; font-family: 'SF Mono',SFMono-Regular,Consolas,monospace;
     font-size: 13px; line-height: 1.5; padding: 16px 20px; color: var(--text);
@@ -7475,6 +7476,7 @@
       }
       let sourceBadge = '';
       if (c.source === 'pkood') sourceBadge = '<span class="source-badge pkood">pkood</span>';
+      else if (c.source === 'codex' || c.engine === 'codex') sourceBadge = '<span class="source-badge codex">codex</span>';
       // Prefer "last interacted" (the user's last UI action) over "last
       // event" (which includes Claude's autonomous responses) so the row
       // time mirrors the user's mental model: when did *I* last touch this?

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -99,6 +99,18 @@ class TestServerImports(unittest.TestCase):
         self.assertFalse(result["available"])
         self.assertIn("reason", result)
 
+    def test_spawn_session_codex_exists(self):
+        """`spawn_session_codex` must exist alongside `spawn_session`
+        with the same (prompt, name=None, cwd=None) signature so the
+        new endpoint can call it the same way."""
+        for mod in ("server", "morning", "morning_store"):
+            sys.modules.pop(mod, None)
+        server = importlib.import_module("server")
+        self.assertTrue(hasattr(server, "spawn_session_codex"))
+        import inspect
+        sig = inspect.signature(server.spawn_session_codex)
+        self.assertEqual(list(sig.parameters), ["prompt", "name", "cwd"])
+
 
 class TestHealthcheck(unittest.TestCase):
     def test_healthcheck_returns_structured_result(self):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5,8 +5,11 @@ gitignored alongside the Morning plugin itself; CI never sees it.
 """
 import importlib
 import os
+import stat
 import sys
+import tempfile
 import unittest
+from unittest import mock
 
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -64,23 +67,21 @@ class TestServerImports(unittest.TestCase):
         server = importlib.import_module("server")
         self.assertTrue(hasattr(server, "_resolve_codex_bin"))
 
-        import tempfile, stat
         with tempfile.NamedTemporaryFile(prefix="codex-", suffix=".sh", delete=False) as f:
             f.write(b"#!/bin/sh\nexit 0\n")
             fake_bin = f.name
         os.chmod(fake_bin, os.stat(fake_bin).st_mode | stat.S_IXUSR)
 
-        prev = os.environ.get("CCC_CODEX_BIN")
         try:
-            os.environ["CCC_CODEX_BIN"] = fake_bin
-            result = server._resolve_codex_bin()
+            with mock.patch.dict(os.environ, {"CCC_CODEX_BIN": fake_bin}), \
+                 mock.patch.object(server.shutil, "which", return_value="/sentinel/from/path"), \
+                 mock.patch.object(server, "CODEX_APP_BUNDLE_PATH", "/sentinel/from/bundle"):
+                result = server._resolve_codex_bin()
+            # Env override must win over both the PATH lookup and the bundle path.
             self.assertEqual(result["bin"], fake_bin)
+            self.assertEqual(result["source"], "env")
             self.assertTrue(result["available"])
         finally:
-            if prev is None:
-                os.environ.pop("CCC_CODEX_BIN", None)
-            else:
-                os.environ["CCC_CODEX_BIN"] = prev
             os.unlink(fake_bin)
 
     def test_resolve_codex_bin_returns_unavailable_when_missing(self):
@@ -91,26 +92,12 @@ class TestServerImports(unittest.TestCase):
         for mod in ("server", "morning", "morning_store"):
             sys.modules.pop(mod, None)
         server = importlib.import_module("server")
-        prev = os.environ.get("CCC_CODEX_BIN")
-        try:
-            os.environ["CCC_CODEX_BIN"] = "/definitely/does/not/exist/codex"
-            # Patch resolver helpers so we don't depend on host state.
-            orig_which = server.shutil.which
-            orig_isfile = server.os.path.isfile
-            server.shutil.which = lambda name: None
-            server.os.path.isfile = lambda p: False if "codex" in p else orig_isfile(p)
-            try:
-                result = server._resolve_codex_bin()
-            finally:
-                server.shutil.which = orig_which
-                server.os.path.isfile = orig_isfile
-            self.assertFalse(result["available"])
-            self.assertIn("reason", result)
-        finally:
-            if prev is None:
-                os.environ.pop("CCC_CODEX_BIN", None)
-            else:
-                os.environ["CCC_CODEX_BIN"] = prev
+        with mock.patch.dict(os.environ, {"CCC_CODEX_BIN": "/definitely/does/not/exist/codex"}), \
+             mock.patch.object(server.shutil, "which", return_value=None), \
+             mock.patch.object(server, "CODEX_APP_BUNDLE_PATH", "/nope/does-not-exist"):
+            result = server._resolve_codex_bin()
+        self.assertFalse(result["available"])
+        self.assertIn("reason", result)
 
 
 class TestHealthcheck(unittest.TestCase):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -111,6 +111,57 @@ class TestServerImports(unittest.TestCase):
         sig = inspect.signature(server.spawn_session_codex)
         self.assertEqual(list(sig.parameters), ["prompt", "name", "cwd"])
 
+    def test_record_spawn_to_registry_persists_engine(self):
+        """The on-disk spawn registry must round-trip an `engine` field
+        so a CCC restart can branch claude-vs-codex reattach logic."""
+        for mod in ("server", "morning", "morning_store"):
+            sys.modules.pop(mod, None)
+        server = importlib.import_module("server")
+        import json, pathlib
+        with tempfile.TemporaryDirectory() as tmp:
+            registry_file = pathlib.Path(tmp) / "spawned-pids.json"
+            orig = server.SPAWNED_PIDS_FILE
+            server.SPAWNED_PIDS_FILE = registry_file
+            try:
+                server._record_spawn_to_registry(
+                    pid=99999, name="t", log_path=pathlib.Path(tmp) / "x.log",
+                    cwd=tmp, spawned_at="20260430T000000",
+                    command_summary="test", fifo=None, engine="codex",
+                )
+                with registry_file.open() as f:
+                    rows = json.load(f)
+                self.assertEqual(rows[-1]["engine"], "codex")
+            finally:
+                server.SPAWNED_PIDS_FILE = orig
+
+    def test_pid_is_engine_process_recognises_codex(self):
+        """`_pid_is_engine_process` must accept an `engine` arg and match
+        the right argv[0] basename for it (`claude` or `codex`)."""
+        for mod in ("server", "morning", "morning_store"):
+            sys.modules.pop(mod, None)
+        server = importlib.import_module("server")
+        self.assertTrue(hasattr(server, "_pid_is_engine_process"))
+        import subprocess as sp
+        prev_run = sp.run
+        def fake_run(args, **kw):
+            class R: pass
+            r = R(); r.returncode = 0; r.stdout = ""; r.stderr = ""
+            if args[:2] == ["ps", "-p"]:
+                pid = args[2]
+                if pid == "11111":
+                    r.stdout = "/usr/local/bin/claude -p --verbose\n"
+                elif pid == "22222":
+                    r.stdout = "/Applications/Codex.app/Contents/Resources/codex exec --json\n"
+            return r
+        sp.run = fake_run
+        try:
+            self.assertTrue(server._pid_is_engine_process(11111, "claude"))
+            self.assertFalse(server._pid_is_engine_process(11111, "codex"))
+            self.assertTrue(server._pid_is_engine_process(22222, "codex"))
+            self.assertFalse(server._pid_is_engine_process(22222, "claude"))
+        finally:
+            sp.run = prev_run
+
 
 class TestHealthcheck(unittest.TestCase):
     def test_healthcheck_returns_structured_result(self):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -55,6 +55,63 @@ class TestServerImports(unittest.TestCase):
             self.assertFalse(server.MORNING_ENABLED,
                              "MORNING_ENABLED must be False when plugin missing")
 
+    def test_resolve_codex_bin_prefers_env_override(self):
+        """`_resolve_codex_bin` must honour CCC_CODEX_BIN when it points
+        at an executable file. Verifies the precedence head — env var
+        always wins over `which codex` and the app-bundle fallback."""
+        for mod in ("server", "morning", "morning_store"):
+            sys.modules.pop(mod, None)
+        server = importlib.import_module("server")
+        self.assertTrue(hasattr(server, "_resolve_codex_bin"))
+
+        import tempfile, stat
+        with tempfile.NamedTemporaryFile(prefix="codex-", suffix=".sh", delete=False) as f:
+            f.write(b"#!/bin/sh\nexit 0\n")
+            fake_bin = f.name
+        os.chmod(fake_bin, os.stat(fake_bin).st_mode | stat.S_IXUSR)
+
+        prev = os.environ.get("CCC_CODEX_BIN")
+        try:
+            os.environ["CCC_CODEX_BIN"] = fake_bin
+            result = server._resolve_codex_bin()
+            self.assertEqual(result["bin"], fake_bin)
+            self.assertTrue(result["available"])
+        finally:
+            if prev is None:
+                os.environ.pop("CCC_CODEX_BIN", None)
+            else:
+                os.environ["CCC_CODEX_BIN"] = prev
+            os.unlink(fake_bin)
+
+    def test_resolve_codex_bin_returns_unavailable_when_missing(self):
+        """When CCC_CODEX_BIN points at a non-existent path AND the
+        Codex.app bundle is absent AND `which codex` finds nothing,
+        the resolver must return {available: False, reason: ...}
+        rather than raising."""
+        for mod in ("server", "morning", "morning_store"):
+            sys.modules.pop(mod, None)
+        server = importlib.import_module("server")
+        prev = os.environ.get("CCC_CODEX_BIN")
+        try:
+            os.environ["CCC_CODEX_BIN"] = "/definitely/does/not/exist/codex"
+            # Patch resolver helpers so we don't depend on host state.
+            orig_which = server.shutil.which
+            orig_isfile = server.os.path.isfile
+            server.shutil.which = lambda name: None
+            server.os.path.isfile = lambda p: False if "codex" in p else orig_isfile(p)
+            try:
+                result = server._resolve_codex_bin()
+            finally:
+                server.shutil.which = orig_which
+                server.os.path.isfile = orig_isfile
+            self.assertFalse(result["available"])
+            self.assertIn("reason", result)
+        finally:
+            if prev is None:
+                os.environ.pop("CCC_CODEX_BIN", None)
+            else:
+                os.environ["CCC_CODEX_BIN"] = prev
+
 
 class TestHealthcheck(unittest.TestCase):
     def test_healthcheck_returns_structured_result(self):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,7 +4,9 @@ Anything Morning-specific lives in `tests/test_morning.py` which is
 gitignored alongside the Morning plugin itself; CI never sees it.
 """
 import importlib
+import json
 import os
+import pathlib
 import stat
 import sys
 import tempfile
@@ -117,7 +119,6 @@ class TestServerImports(unittest.TestCase):
         for mod in ("server", "morning", "morning_store"):
             sys.modules.pop(mod, None)
         server = importlib.import_module("server")
-        import json, pathlib
         with tempfile.TemporaryDirectory() as tmp:
             registry_file = pathlib.Path(tmp) / "spawned-pids.json"
             orig = server.SPAWNED_PIDS_FILE
@@ -141,8 +142,7 @@ class TestServerImports(unittest.TestCase):
             sys.modules.pop(mod, None)
         server = importlib.import_module("server")
         self.assertTrue(hasattr(server, "_pid_is_engine_process"))
-        import subprocess as sp
-        prev_run = sp.run
+
         def fake_run(args, **kw):
             class R: pass
             r = R(); r.returncode = 0; r.stdout = ""; r.stderr = ""
@@ -153,14 +153,52 @@ class TestServerImports(unittest.TestCase):
                 elif pid == "22222":
                     r.stdout = "/Applications/Codex.app/Contents/Resources/codex exec --json\n"
             return r
-        sp.run = fake_run
-        try:
+
+        with mock.patch.object(server.subprocess, "run", side_effect=fake_run):
             self.assertTrue(server._pid_is_engine_process(11111, "claude"))
             self.assertFalse(server._pid_is_engine_process(11111, "codex"))
             self.assertTrue(server._pid_is_engine_process(22222, "codex"))
             self.assertFalse(server._pid_is_engine_process(22222, "claude"))
-        finally:
-            sp.run = prev_run
+
+    def test_reattach_spawned_orphans_defaults_legacy_rows_to_claude(self):
+        """A registry row written before the `engine` field existed
+        must reattach as engine='claude' — not raise KeyError, not
+        silently drop the row."""
+        for mod in ("server", "morning", "morning_store"):
+            sys.modules.pop(mod, None)
+        server = importlib.import_module("server")
+        with tempfile.TemporaryDirectory() as tmp:
+            registry_file = pathlib.Path(tmp) / "spawned-pids.json"
+            log_file = pathlib.Path(tmp) / "fake.log"
+            log_file.write_text("")
+            # Legacy row — no `engine` key. PID is the current process so
+            # the os.kill(pid, 0) liveness check succeeds without faking.
+            legacy = [{
+                "pid": os.getpid(),
+                "session_id": None,
+                "name": "legacy",
+                "log": str(log_file),
+                "fifo": None,
+                "cwd": tmp,
+                "spawned_at": "20260101T000000",
+                "command_summary": "old row",
+            }]
+            registry_file.write_text(json.dumps(legacy))
+            orig_registry = server.SPAWNED_PIDS_FILE
+            orig_sessions = list(server._spawned_sessions)
+            server.SPAWNED_PIDS_FILE = registry_file
+            server._spawned_sessions.clear()
+            try:
+                # Bypass the real ps-grep — current pid isn't a `claude`
+                # process, so without a stub it would be dropped.
+                with mock.patch.object(server, "_pid_is_engine_process", return_value=True):
+                    server._reattach_spawned_orphans()
+                self.assertEqual(len(server._spawned_sessions), 1)
+                self.assertEqual(server._spawned_sessions[0]["engine"], "claude")
+            finally:
+                server.SPAWNED_PIDS_FILE = orig_registry
+                server._spawned_sessions.clear()
+                server._spawned_sessions.extend(orig_sessions)
 
 
 class TestHealthcheck(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds OpenAI Codex as a second spawn engine alongside the existing headless Claude path. The toolbar's `pkood spawn` checkbox is replaced by a 2-way **Engine** dropdown (`claude` | `codex`), mirrored into the new-session modal. Picking `codex` routes through `codex exec --json --dangerously-bypass-approvals-and-sandbox --model <model> --cd <cwd>` instead of `claude -p`, runs in the chosen working directory, and tracks the child on the same kanban with a green `codex` chip.

This is a fire-and-watch MVP — no mid-run inject (Codex `exec` is one-shot), no `claude --resume`-style jump-in, no Codex JSONL ingestion. The spec deliberately defers those to a later iteration; see `docs/superpowers/specs/2026-04-28-codex-spawn-design.md`.

The `pkood:` prompt-prefix shortcut and `/api/pkood/spawn` endpoint are unchanged so the orchestration layer keeps working.

### What's new

- `_resolve_codex_bin()` — locates the Codex CLI via `$CCC_CODEX_BIN` → `which codex` → `/Applications/Codex.app/Contents/Resources/codex`
- `spawn_session_codex()` — mirrors `spawn_session` for the Codex path; one-shot, no FIFO
- `engine="claude"|"codex"` field threaded through `_record_spawn_to_registry`, `SPAWNED_PIDS_FILE`, `_reattach_spawned_orphans`, `_pid_is_engine_process` (replaces `_pid_is_claude_process`), and `find_all_sessions`
- `POST /api/sessions/spawn-codex` — same payload + validation as `/api/sessions/spawn`, plus `cwd` clamped to `$HOME` (parity with the Claude endpoint, important since Codex spawns with `--dangerously-bypass-approvals-and-sandbox`)
- `GET /api/sessions/spawn-codex/availability` — frontend probes this on load + window focus to grey out the codex option when the binary is missing
- `503` + sentinel `code: "codex_unavailable"` so the frontend can render an install hint without parsing prose
- New env vars: `CCC_CODEX_BIN`, `CCC_CODEX_MODEL` (default `gpt-5.5` — verified live against codex-cli 0.125.0-alpha.3; the spec's original `gpt-5.5-codex` was rejected)
- Source badge: small green `codex` chip mirroring the orange `pkood` chip
- 4 new smoke tests in `tests/test_smoke.py` covering resolver precedence, registry round-trip, ps-grep engine selectivity, and the legacy-row reattach default
- Version bump 0.2.1 → 0.3.0

### Out of scope (deferred)

- `~/.codex/sessions/*.jsonl` ingestion (titles, conversation panel, branch detection for Codex cards)
- "Open in terminal" / `codex resume <id>` jump-in
- Auto-titling via Haiku
- Hooks pipeline equivalents (Codex doesn't fire CCC's hooks)
- Mid-run `inject_into_spawned`

## Test plan

- [ ] Engine dropdown appears in the View menu with `claude` (default) and `codex` options
- [ ] Selection persists in localStorage as `ccc.spawnEngine`
- [ ] New-session modal mirrors the toolbar's selection on open
- [ ] Picking `claude` + Run still routes to `/api/sessions/spawn` (regression check)
- [ ] Picking `codex` + Run routes to `/api/sessions/spawn-codex`, log lands at `~/.claude/command-center/logs/spawn-codex-*-*.log`, JSONL events stream
- [ ] Codex card appears on kanban with a green `codex` chip
- [ ] `pkood:` prompt-prefix shortcut still routes to `/api/pkood/spawn`
- [ ] `CCC_CODEX_BIN=/tmp/does-not-exist ./run.sh` greys out the codex option in both selectors
- [ ] `cwd` outside `$HOME` returns 400 (e.g. `cwd: "/etc"`)
- [ ] CCC restart mid-spawn: codex card reattaches via `_reattach_spawned_orphans` without trying to read a `~/.claude/projects` JSONL
- [ ] `python3 -m unittest tests.test_smoke -v` → 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)