### PR TITLE
fix(server): tail-meta detects `git -C <path> commit/push`

### DIFF
--- a/changelog.d/fixed-tail-meta-git-c-form-2026-05-02.md
+++ b/changelog.d/fixed-tail-meta-git-c-form-2026-05-02.md
@@ -1,0 +1,1 @@
+Tail-meta `has_commit` / `has_push` now detect the `git -C <path> commit/push` form (and other flag-prefixed `git` invocations like `git --no-pager commit` or `git -c key=val push`). Multi-worktree sessions no longer render as "uncommitted" after a real commit just because the command used the form CLAUDE.md mandates for shared-clone safety.

--- a/server.py
+++ b/server.py
@@ -1958,6 +1958,16 @@ def _extract_tail_meta(path):
     _gh_url_re = re.compile(r'github\.com/[^/\s]+/[^/\s]+/issues/(\d{1,6})')
     _gh_pr_create_re = re.compile(r'\bgh\s+pr\s+create\b')
     _gh_pr_url_re = re.compile(r'github\.com/([^/\s]+/[^/\s]+)/pull/(\d{1,7})')
+    # Git subcommand detector — survives the `git -C <path>` /
+    # `git --git-dir=<x>` / `git -c key=val` flag prefixes that CLAUDE.md
+    # mandates for shared-clone multi-session work. Naive `"git commit"
+    # in cmd` substring checks miss every one of those forms, so a real
+    # commit on a sibling worktree never flips has_commit and the row's
+    # "committed" pill never lights up. Up to 8 flag tokens are tolerated
+    # before the subcommand; `-C <arg>` / `-c <arg>` consume their value.
+    _git_subcmd_re = re.compile(
+        r'\bgit\b(?:\s+(?:-[Cc]\s+\S+|--\S+|-[A-Za-z]\S*)){0,8}\s+(commit|push)\b'
+    )
     _pending_pr_ids = set()
     _pos = 0
     try:
@@ -2027,12 +2037,25 @@ def _extract_tail_meta(path):
                             meta["last_edit_pos"] = _pos
                         elif name == "Bash":
                             cmd = inp.get("command", "")
-                            if "git commit" in cmd:
-                                meta["has_commit"] = True
-                                meta["last_commit_pos"] = _pos
-                            if "git push" in cmd:
-                                meta["has_push"] = True
-                                meta["last_push_pos"] = _pos
+                            # Detect `git commit` / `git push` tool calls.
+                            # Walk shell segments so chained
+                            # `git commit … && git push …` registers both,
+                            # and trim each segment at the `-m`/`--message`
+                            # flag so a commit message body containing
+                            # the word "push" can't false-fire has_push
+                            # (and vice versa).
+                            for _seg in re.split(r'\s*(?:&&|\|\||\||;|\n)\s*', cmd):
+                                _seg_head = re.split(r'\s+(?:-m\b|--message\b)', _seg, maxsplit=1)[0]
+                                _m = _git_subcmd_re.search(_seg_head)
+                                if not _m:
+                                    continue
+                                _sub = _m.group(1)
+                                if _sub == "commit":
+                                    meta["has_commit"] = True
+                                    meta["last_commit_pos"] = _pos
+                                elif _sub == "push":
+                                    meta["has_push"] = True
+                                    meta["last_push_pos"] = _pos
                             # Drift indicator: any `cd <path>` or `git -C <path>`
                             # means the session may have moved across repos.
                             # Used by find_conversations() to skip the


### PR DESCRIPTION
## Summary

- Replace naive `\"git commit\" in cmd` / `\"git push\" in cmd` substring checks in `_extract_tail_meta` with a flag-tolerant regex that handles `git -C <path>`, `git --git-dir=<x>`, `git -c k=v`, and other prefix forms — i.e. every `git` invocation CLAUDE.md actively mandates for shared-clone safety.
- Walk shell segments split on `&&` / `||` / `|` / `;` / newline so chained `git commit … && git push …` registers both `has_commit` and `has_push`.
- Trim each segment at `-m`/`--message` so a commit message containing the word \"push\" can't false-fire `has_push` (and the reverse).

## Why

The row-list \"committed\" and \"push\" pills stayed dark forever for any session that committed via the multi-worktree `git -C <path> commit …` form — the substring `\"git commit\"` simply isn't present in those commands. Every well-behaved multi-session contributor was being mis-pilled. Caught while debugging why session `00d4bb60-…` (which had two real commits in this very session) showed as uncommitted.

## Test plan

- [x] `python3 -m compileall server.py` — clean
- [x] `import server` — clean
- [x] Regex sanity tests against 8 representative inputs (`git commit`, `git -C /p commit`, `git --no-pager commit`, `git -c k=v commit`, plus `push` variants, plus `git status` no-match, plus chained `commit && push`) — all expected.
- [x] Commit-message body containing \"push\" no longer false-fires `has_push`.
- [x] `git merge-tree origin/main HEAD` clean — no conflicts with the 5 commits that landed on main during this session.
- [ ] After merge: dashboard restart, confirm sessions that committed via `git -C <path>` now light up the \"committed\" row pill.