### PR TITLE
Hide generated helper sessions in All repos

### DIFF
--- a/changelog.d/fixed-generated-helper-sessions-all-repos-2026-05-03.md
+++ b/changelog.d/fixed-generated-helper-sessions-all-repos-2026-05-03.md
@@ -1,0 +1,1 @@
+- All repos mode now hides CCC-generated helper sessions such as title summarizer prompts and one-off image-read JSON extractors. The active repo list and cross-repo archive now share the same generated-helper filter, so these utility JSONLs no longer appear as normal work rows.

--- a/server.py
+++ b/server.py
@@ -646,6 +646,25 @@ def _decode_project_slug(slug):
         return None
 
 
+_GENERATED_HELPER_SESSION_PREFIXES = (
+    "Produce a concise 4-8 word title summarizing what the user is trying to do",
+    "Produce a concise 4-8 word title for the GitHub issue below",
+)
+
+
+def _is_generated_helper_session(first_message):
+    """Return True for CCC's own throwaway utility prompts."""
+    text = (first_message or "").lstrip()
+    if not text:
+        return False
+    if text.startswith(_GENERATED_HELPER_SESSION_PREFIXES):
+        return True
+    return (
+        text.startswith("Use the Read tool to open this image:")
+        and "Then output ONLY a single JSON line" in text[:500]
+    )
+
+
 def find_all_conversations(limit_per_folder=None):
     """Walk ~/.claude/projects/ for every subdir and return a flat list of
     conversation metadata across every folder you've ever Claude-Code'd in.
@@ -758,11 +777,11 @@ def find_all_conversations(limit_per_folder=None):
                         if not first_message and ev.get("type") == "user":
                             msg = (ev.get("message") or {}).get("content")
                             if isinstance(msg, str):
-                                first_message = msg.strip()[:200]
+                                first_message = msg.strip()
                             elif isinstance(msg, list):
                                 for part in msg:
                                     if isinstance(part, dict) and part.get("type") == "text":
-                                        first_message = (part.get("text") or "").strip()[:200]
+                                        first_message = (part.get("text") or "").strip()
                                         break
                         if not git_branch:
                             git_branch = ev.get("gitBranch") or ev.get("git_branch")
@@ -774,6 +793,9 @@ def find_all_conversations(limit_per_folder=None):
                             break
             except (OSError, UnicodeDecodeError):
                 pass
+
+            if _is_generated_helper_session(first_message):
+                continue
 
             # Tool-call inference — match what extract_session_workspace
             # does for active sessions. The JSONL's first-event cwd /
@@ -918,7 +940,7 @@ def find_all_conversations(limit_per_folder=None):
                 "session_cwd_is_worktree": cwd_is_worktree,
                 "mtime": stat.st_mtime,
                 "size": stat.st_size,
-                "first_message": first_message,
+                "first_message": first_message[:200] if first_message else None,
                 # Both keys: `branch`/`git_branch` is the JSONL's literal
                 # gitBranch (what the row defaults to when no inference);
                 # `effective_branch`/`effective_kind` carry the tool-call
@@ -5032,18 +5054,6 @@ def find_conversations(progress=None, include_old=True, live_sids=None):
     if live_sids is None and not include_old:
         live_sids = set(_load_session_registry().keys())
     live_sids = set(live_sids or [])
-    # Skip sessions created by our own `claude -p` title-summarizer calls.
-    # The summarizer prompts start with these exact prefixes (see
-    # summarize_session_title / the GitHub-issue title summarizer). Without
-    # this filter, every click of the ✨ Titles button creates a throwaway
-    # session that then pollutes the kanban with a "Produce a concise 4-8
-    # word title…" card. Match is on first_message prefix, which is resilient
-    # to user renames — the prompt text itself can't be overridden.
-    _TITLE_SUMMARIZER_PREFIXES = (
-        "Produce a concise 4-8 word title summarizing what the user is trying to do",
-        "Produce a concise 4-8 word title for the GitHub issue below",
-    )
-
     # If the same session_id (file name) appears in multiple candidate
     # dirs (unlikely — claude-code uses one slug per process — but
     # possible if a repo path was historically encoded both ways), the
@@ -5186,10 +5196,10 @@ def find_conversations(progress=None, include_old=True, live_sids=None):
             _t_head += time.perf_counter() - _t0
             _n_head += 1
 
-        # Drop throwaway title-summarizer sessions before spending any more work
-        # on them (tail scan, cwd lookup, etc.). first_message peek above already
-        # strips <command-name> wrappers, so a plain prefix compare is enough.
-        if first_message and first_message.lstrip().startswith(_TITLE_SUMMARIZER_PREFIXES):
+        # Drop generated helper sessions before spending any more work on
+        # them (tail scan, cwd lookup, etc.). first_message peek above already
+        # strips <command-name> wrappers, so prompt-shape matching is enough.
+        if _is_generated_helper_session(first_message):
             continue
 
         conv_id = f.name[:-6]  # remove .jsonl

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -42,6 +42,71 @@ def _fresh_server():
     return importlib.import_module("server")
 
 
+def _write_user_jsonl(path, session_id, content, cwd):
+    event = {
+        "type": "user",
+        "message": {"role": "user", "content": content},
+        "timestamp": "2026-05-02T00:00:00.000Z",
+        "cwd": str(cwd),
+        "sessionId": session_id,
+        "gitBranch": "main",
+    }
+    path.write_text(json.dumps(event) + "\n", encoding="utf-8")
+
+
+class TestGeneratedHelperSessionFilter(unittest.TestCase):
+    def test_all_repos_hides_generated_helper_sessions(self):
+        tmp_home = tempfile.mkdtemp(prefix="ccc-all-repos-home-")
+        prev_home = os.environ.get("HOME")
+        try:
+            resolved_home = Path(tmp_home).resolve()
+            os.environ["HOME"] = str(resolved_home)
+            server = _fresh_server()
+
+            repo = resolved_home / "demo-repo"
+            repo.mkdir()
+            project_dir = resolved_home / ".claude" / "projects" / "-demo-repo"
+            project_dir.mkdir(parents=True)
+
+            real_sid = "00000000-0000-4000-8000-000000000001"
+            title_sid = "00000000-0000-4000-8000-000000000002"
+            image_sid = "00000000-0000-4000-8000-000000000003"
+            _write_user_jsonl(
+                project_dir / f"{real_sid}.jsonl",
+                real_sid,
+                "please update the clients report",
+                repo,
+            )
+            _write_user_jsonl(
+                project_dir / f"{title_sid}.jsonl",
+                title_sid,
+                "Produce a concise 4-8 word title summarizing what the user is trying to do below.",
+                repo,
+            )
+            _write_user_jsonl(
+                project_dir / f"{image_sid}.jsonl",
+                image_sid,
+                "Use the Read tool to open this image: '/Users/test/Downloads/example.png'. "
+                "Then output ONLY a single JSON line, no other text",
+                repo,
+            )
+
+            rows = server.find_all_conversations()
+            sids = {r["session_id"] for r in rows}
+
+            self.assertIn(real_sid, sids)
+            self.assertNotIn(title_sid, sids)
+            self.assertNotIn(image_sid, sids)
+        finally:
+            if prev_home is None:
+                os.environ.pop("HOME", None)
+            else:
+                os.environ["HOME"] = prev_home
+            for mod in ("server", "morning", "morning_store"):
+                sys.modules.pop(mod, None)
+            shutil.rmtree(tmp_home, ignore_errors=True)
+
+
 class TestExtractTailMetaPrLink(unittest.TestCase):
     def test_pr_link_event_sets_tail_pr_fields(self):
         server = _fresh_server()


### PR DESCRIPTION
## Summary
- add a shared detector for CCC-generated helper prompts
- hide title-summarizer and image-read helper JSONLs from All repos
- keep active repo and All repos filtering behavior aligned

## Tests
- python3 -m unittest