### PR TITLE
feat(ui): archive search matches session UUID

### DIFF
--- a/changelog.d/added-archive-uuid-search-2026-05-03.md
+++ b/changelog.d/added-archive-uuid-search-2026-05-03.md
@@ -1,0 +1,1 @@
+- Archive search input now matches against the session UUID, so you can paste a `session_id` (e.g. `9858e87d-73bd-419f-9e8b-5d89eb9db9a1`) and find the conversation directly. Useful when CCC tooling, logs, or external scripts surface a UUID without a title.

--- a/static/index.html
+++ b/static/index.html
@@ -13526,7 +13526,10 @@
       ? archiveRows
       : archiveRows.filter(c => _archiveFolderValue(c) === archiveFolderFilter);
     const rows = q ? byFolder.filter(c =>
-      ((c.display_name || '') + ' ' + (c.first_message || '') + ' ' + (c.folder_label || '') + ' ' + (c.git_branch || '') + ' ' + (c.branch || ''))
+      // session_id + id let users paste a session UUID into the search box
+      // and find the conversation directly — useful when CCC tooling, logs
+      // or external scripts surface a UUID without a title.
+      ((c.display_name || '') + ' ' + (c.first_message || '') + ' ' + (c.folder_label || '') + ' ' + (c.git_branch || '') + ' ' + (c.branch || '') + ' ' + (c.session_id || '') + ' ' + (c.id || ''))
         .toLowerCase().includes(q)
     ) : byFolder;
 


### PR DESCRIPTION
## Summary
Pasting a session UUID into the All-repos search input now finds the conversation. One-line change to `renderArchiveList`'s row filter — appends `c.session_id` and `c.id` to the searchable concatenation.

## Why
CCC tooling, logs, error reports, and external scripts often surface a session UUID without a title. Without UUID search, you couldn't jump from "I have this UUID" to "open that conversation" — you had to scan visually.

## Test plan
- [ ] Paste any session UUID into the search input → matching conversation appears.
- [ ] Paste a partial UUID (first 8 chars) → still matches via `includes`.
- [ ] Existing search by title / folder / branch still works.
- [ ] `tests/test_smoke.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)