### PR TITLE
feat(gemini): add Gemini session engine

### DIFF
--- a/changelog.d/added-gemini-engine-2026-05-04.md
+++ b/changelog.d/added-gemini-engine-2026-05-04.md
@@ -1,0 +1,1 @@
+- Add Gemini CLI as a third session engine with discovery, transcript viewing, token usage, spawn/resume, and activity/commit signals.

--- a/server.py
+++ b/server.py
@@ -3723,6 +3723,43 @@ def find_live_codex_processes():
     return procs
 
 
+def find_live_gemini_processes():
+    """Return running Gemini CLI processes with pid, tty, cwd, terminal app, command."""
+    procs = []
+    try:
+        ps_out = subprocess.run(
+            ["ps", "-A", "-o", "pid=,tty=,comm=,args="],
+            capture_output=True, text=True, timeout=2,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return procs
+    for line in ps_out.stdout.splitlines():
+        parts = line.strip().split(None, 3)
+        if len(parts) < 3:
+            continue
+        pid_s, tty, comm = parts[:3]
+        args = parts[3] if len(parts) > 3 else ""
+        arg_parts = args.split()
+        basenames = {comm.rsplit("/", 1)[-1]}
+        basenames.update(p.rsplit("/", 1)[-1] for p in arg_parts[:4])
+        if "gemini" not in basenames:
+            continue
+        try:
+            pid = int(pid_s)
+        except ValueError:
+            continue
+        cwd = _proc_cwd(pid)
+        term_app, _term_pid = _proc_ancestor_terminal(pid)
+        procs.append({
+            "pid": pid,
+            "tty": tty if tty != "??" else None,
+            "cwd": cwd,
+            "terminal_app": term_app,
+            "command": args,
+        })
+    return procs
+
+
 def _load_session_registry():
     """Read ~/.claude/sessions/*.json and return {session_id: {pid, cwd, ...}}.
 
@@ -3825,6 +3862,37 @@ def session_live_status(session_id, session_cwd):
         result["live"] = True
         return result
 
+    if _is_gemini_session(session_id):
+        path = _resolve_gemini_chat_path(session_id)
+        if path:
+            try:
+                result["recently_written"] = (time.time() - path.stat().st_mtime) < 300
+            except OSError:
+                pass
+        if not session_cwd:
+            session_cwd = find_session_cwd(session_id)
+        matches = []
+        for p in find_live_gemini_processes():
+            cmd = p.get("command") or ""
+            if session_id in cmd or (session_cwd and p.get("cwd") == session_cwd):
+                matches.append(p)
+        result["match_count"] = len(matches)
+        if not matches:
+            return result
+        if len(matches) > 1:
+            exact = [p for p in matches if session_id in (p.get("command") or "")]
+            if len(exact) == 1:
+                matches = exact
+            else:
+                result["ambiguous"] = True
+                return result
+        match = matches[0]
+        result["pid"] = match["pid"]
+        result["tty"] = match.get("tty")
+        result["terminal_app"] = match.get("terminal_app")
+        result["live"] = True
+        return result
+
     # Recency check on the .jsonl file (for the "is actively being used" signal)
     jsonl_name = session_id + ".jsonl"
     recent = False
@@ -3907,7 +3975,13 @@ def _shell_quote(s):
 def _build_resume_command(session_id, cwd, cwd_exists):
     """Same logic as the frontend buildResumeCommand — keep them in sync."""
     is_codex = _is_codex_session(session_id)
-    resume_cmd = f"codex resume {session_id}" if is_codex else f"claude --resume {session_id}"
+    is_gemini = _is_gemini_session(session_id)
+    if is_codex:
+        resume_cmd = f"codex resume {session_id}"
+    elif is_gemini:
+        resume_cmd = f"gemini --resume {session_id}"
+    else:
+        resume_cmd = f"claude --resume {session_id}"
     if not cwd:
         return resume_cmd
     q_cwd = _shell_quote(cwd)
@@ -4574,6 +4648,12 @@ def find_session_cwd(session_id):
                 cwd = tail.get("cwd") or cwd
             except Exception:
                 pass
+        if cwd:
+            _session_cwd_cache[session_id] = cwd
+            return cwd
+    gemini_path = _resolve_gemini_chat_path(session_id)
+    if gemini_path:
+        cwd = _gemini_project_root_for_chat(gemini_path)
         if cwd:
             _session_cwd_cache[session_id] = cwd
             return cwd
@@ -6022,6 +6102,19 @@ def find_all_sessions(repo_path, progress=None, include_old=True):
         if progress:
             progress("codex", state="error", detail=f"Codex thread scan failed: {exc}")
 
+    if progress:
+        progress("gemini", state="running", detail="Reading Gemini sessions.")
+    try:
+        conversations.extend(find_gemini_conversations(
+            repo_path=repo_path,
+            include_old=include_old,
+            repo_only=True,
+            progress=progress,
+        ))
+    except Exception as exc:
+        if progress:
+            progress("gemini", state="error", detail=f"Gemini session scan failed: {exc}")
+
     # Add pkood agents — and merge in their linked claude-session card, if any.
     # Pkood spawns a claude process in a tmux pty, which produces a regular
     # ~/.claude/projects/*/*.jsonl file. Without dedup the kanban would show
@@ -6152,7 +6245,7 @@ def find_all_sessions(repo_path, progress=None, include_old=True):
         )
     desktop_meta = _load_desktop_app_metadata()
     for c in conversations:
-        if c.get("source") != "codex":
+        if c.get("source") not in ("codex", "gemini"):
             _add_sidecar_fields(c)
         # Desktop-app metadata decoration: use human-friendly title if present,
         # and flag the session as having been touched by the desktop app.
@@ -6279,6 +6372,8 @@ def _resolve_conversation_reader(conversation_id, repo_path=None):
 
 def parse_conversation(conversation_id, after_line=0, repo_path=None):
     """Parse a conversation JSONL file into structured events."""
+    if _is_gemini_session(conversation_id):
+        return _parse_gemini_conversation(conversation_id, after_line=after_line)
     filepath, parser = _resolve_conversation_reader(conversation_id, repo_path=repo_path)
     events = []
     line_num = 0
@@ -6957,7 +7052,9 @@ def _codex_command_signals(cmd):
     )
     subcommands = {m.group(1) for m in git_subcmd.finditer(head)}
     edit_like = bool(re.search(
-        r"\b(apply_patch|tee|sed\s+-i|perl\s+-pi)\b|(?:^|[\s;&|])cat\s+>|write_text\s*\(",
+        r"\b(apply_patch|tee|sed\s+-i|perl\s+-pi)\b|"
+        r"(?:^|[\s;&|])cat\s+>|write_text\s*\(|"
+        r"(?:^|[\s;&|])(?:printf|echo)\b[^;\n]*>\s*\S+",
         cmd,
     ))
     return {
@@ -7754,6 +7851,931 @@ def _extract_codex_timeline(session_id):
     return {"events": events, "total_turns": turn}
 
 
+# ---------------------------------------------------------------------------
+# Gemini CLI integration
+# ---------------------------------------------------------------------------
+
+GEMINI_HOME = Path.home() / ".gemini"
+GEMINI_CONTEXT_LIMIT = 1_000_000
+
+
+def _resolve_gemini_bin():
+    """Locate a usable Gemini CLI binary.
+
+    Priority order mirrors Codex:
+      1. $CCC_GEMINI_BIN when set and executable.
+      2. `shutil.which("gemini")`.
+    """
+    env_bin = os.environ.get("CCC_GEMINI_BIN")
+    if env_bin:
+        if os.path.isfile(env_bin) and os.access(env_bin, os.X_OK):
+            return {"available": True, "bin": env_bin, "source": "env"}
+        return {
+            "available": False,
+            "bin": None,
+            "code": "gemini_unavailable",
+            "reason": f"CCC_GEMINI_BIN is set to {env_bin!r} but it isn't an executable file",
+        }
+    which_bin = shutil.which("gemini")
+    if which_bin:
+        return {"available": True, "bin": which_bin, "source": "path"}
+    return {
+        "available": False,
+        "bin": None,
+        "code": "gemini_unavailable",
+        "reason": "Gemini CLI not found. Install Gemini CLI or set CCC_GEMINI_BIN.",
+    }
+
+
+def _gemini_tmp_root():
+    return GEMINI_HOME / "tmp"
+
+
+def _gemini_chat_paths():
+    root = _gemini_tmp_root()
+    if not root.is_dir():
+        return []
+    paths = []
+    try:
+        for project_dir in root.iterdir():
+            chats = project_dir / "chats"
+            if not chats.is_dir():
+                continue
+            try:
+                paths.extend(p for p in chats.glob("session-*.json") if p.is_file())
+            except OSError:
+                continue
+    except OSError:
+        return []
+    try:
+        paths.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    except OSError:
+        paths.sort(key=lambda p: str(p), reverse=True)
+    return paths
+
+
+def _load_gemini_chat(path):
+    try:
+        data = json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _gemini_project_dir_for_chat(path):
+    try:
+        return Path(path).parent.parent
+    except (TypeError, ValueError):
+        return None
+
+
+def _gemini_project_root_for_chat(path):
+    project_dir = _gemini_project_dir_for_chat(path)
+    if not project_dir:
+        return ""
+    root_file = project_dir / ".project_root"
+    try:
+        return root_file.read_text().strip()
+    except OSError:
+        return ""
+
+
+def _resolve_gemini_chat_path(session_id):
+    if not session_id:
+        return None
+    short = session_id.split("-", 1)[0]
+    paths = _gemini_chat_paths()
+    # Filename embeds the leading UUID segment; check likely matches first.
+    likely = [p for p in paths if short and short in p.name]
+    for p in likely + [p for p in paths if p not in likely]:
+        data = _load_gemini_chat(p)
+        if data and data.get("sessionId") == session_id:
+            return p
+    return None
+
+
+def _is_gemini_session(session_id):
+    return bool(_resolve_gemini_chat_path(session_id))
+
+
+def _iso_ts_epoch(ts):
+    if not ts:
+        return 0.0
+    try:
+        return datetime.fromisoformat(str(ts).replace("Z", "+00:00")).timestamp()
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _gemini_message_text(msg):
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(p for p in parts if p)
+    return ""
+
+
+def _gemini_tool_args(call):
+    args = call.get("args") if isinstance(call, dict) else {}
+    return args if isinstance(args, dict) else {}
+
+
+def _gemini_tool_command(call):
+    args = _gemini_tool_args(call)
+    cmd = args.get("command") or ""
+    return cmd if isinstance(cmd, str) else ""
+
+
+def _gemini_tool_name(call):
+    return (call.get("name") or call.get("displayName") or "tool").rsplit(".", 1)[-1]
+
+
+def _gemini_tool_detail(call):
+    args = _gemini_tool_args(call)
+    cmd = _gemini_tool_command(call)
+    return args.get("description") or cmd or call.get("description") or ""
+
+
+def _gemini_tool_output(call):
+    chunks = []
+    result = call.get("result") if isinstance(call, dict) else None
+    if isinstance(result, list):
+        for item in result:
+            if not isinstance(item, dict):
+                continue
+            response = (((item.get("functionResponse") or {}).get("response") or {}))
+            out = response.get("output") or response.get("error") or ""
+            if isinstance(out, str) and out:
+                chunks.append(out)
+    elif isinstance(result, str):
+        chunks.append(result)
+    return "\n".join(chunks)
+
+
+def _extract_gemini_session_id_from_log(log_path):
+    if not log_path:
+        return None
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line or not line.startswith("{"):
+                    continue
+                try:
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if ev.get("type") == "init" and ev.get("session_id"):
+                    return ev["session_id"]
+    except OSError:
+        return None
+    return None
+
+
+def _gemini_spawn_pid_by_session_id():
+    out = {}
+    for s in _spawned_sessions:
+        if s.get("engine") != "gemini":
+            continue
+        sid = s.get("resumed_sid") or _extract_gemini_session_id_from_log(s.get("log"))
+        if sid and sid not in out:
+            try:
+                alive = s["proc"].poll() is None
+            except Exception:
+                alive = False
+            out[sid] = {
+                "pid": s.get("pid"),
+                "alive": alive,
+                "log": s.get("log"),
+            }
+    return out
+
+
+def _extract_gemini_stream_tail_meta(log_path):
+    meta = {
+        "last_event_type": None,
+        "last_meaningful_ts": 0,
+        "pending_tool": None,
+        "pending_file": None,
+        "model": None,
+    }
+    pending = set()
+    if not log_path:
+        return meta
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line or not line.startswith("{"):
+                    continue
+                try:
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                ts_epoch = _iso_ts_epoch(ev.get("timestamp"))
+                ev_type = ev.get("type")
+                if ev.get("model"):
+                    meta["model"] = ev.get("model") or meta["model"]
+                if ev_type == "message":
+                    role = ev.get("role")
+                    if role == "user":
+                        meta["last_event_type"] = "user"
+                    elif role == "assistant":
+                        meta["last_event_type"] = "assistant"
+                    if ts_epoch:
+                        meta["last_meaningful_ts"] = ts_epoch
+                elif ev_type == "tool_use":
+                    tool_id = ev.get("tool_id") or ""
+                    if tool_id:
+                        pending.add(tool_id)
+                    name = ev.get("tool_name") or "tool"
+                    params = ev.get("parameters") if isinstance(ev.get("parameters"), dict) else {}
+                    detail = params.get("description") or params.get("command") or ""
+                    meta["pending_tool"] = name.rsplit(".", 1)[-1]
+                    meta["pending_file"] = detail[:80] if isinstance(detail, str) else None
+                    meta["last_event_type"] = "assistant"
+                    if ts_epoch:
+                        meta["last_meaningful_ts"] = ts_epoch
+                elif ev_type == "tool_result":
+                    tool_id = ev.get("tool_id") or ""
+                    if tool_id in pending:
+                        pending.discard(tool_id)
+                    if not pending:
+                        meta["pending_tool"] = None
+                        meta["pending_file"] = None
+                    meta["last_event_type"] = "assistant"
+                    if ts_epoch:
+                        meta["last_meaningful_ts"] = ts_epoch
+                elif ev_type == "result":
+                    meta["last_event_type"] = "result"
+                    meta["pending_tool"] = None
+                    meta["pending_file"] = None
+                    if ts_epoch:
+                        meta["last_meaningful_ts"] = ts_epoch
+                    stats = ev.get("stats") if isinstance(ev.get("stats"), dict) else {}
+                    models = stats.get("models") if isinstance(stats.get("models"), dict) else {}
+                    if models:
+                        meta["model"] = next(reversed(models.keys()))
+    except OSError:
+        pass
+    return meta
+
+
+def _extract_gemini_tail_meta(path):
+    try:
+        mtime = Path(path).stat().st_mtime
+    except OSError:
+        return {}
+    cached = _conv_meta_cache.get(str(path))
+    if cached and cached.get("mtime") == mtime and cached.get("engine") == "gemini":
+        return cached
+    data = _load_gemini_chat(path)
+    if not data:
+        return {}
+    meta = {
+        "engine": "gemini",
+        "mtime": mtime,
+        "first_message": None,
+        "last_prompt": None,
+        "last_assistant_text": None,
+        "last_event_type": None,
+        "last_meaningful_ts": 0,
+        "pending_tool": None,
+        "pending_file": None,
+        "has_edit": False,
+        "has_commit": False,
+        "has_push": False,
+        "last_edit_pos": 0,
+        "last_commit_pos": 0,
+        "last_push_pos": 0,
+        "tail_pr_number": None,
+        "tail_pr_url": None,
+        "tail_branch": None,
+        "tail_worktree_path": None,
+        "cwd": _gemini_project_root_for_chat(path),
+        "model": None,
+    }
+    pr_url_re = re.compile(r"github\.com/([^/\s]+/[^/\s]+)/pull/(\d{1,7})")
+    messages = data.get("messages") if isinstance(data.get("messages"), list) else []
+    for pos, msg in enumerate(messages, start=1):
+        if not isinstance(msg, dict):
+            continue
+        ts_epoch = _iso_ts_epoch(msg.get("timestamp"))
+        if ts_epoch:
+            meta["last_meaningful_ts"] = ts_epoch
+        mtype = msg.get("type")
+        if mtype == "user":
+            text = _gemini_message_text(msg).strip()
+            if text:
+                meta["first_message"] = meta["first_message"] or text
+                meta["last_prompt"] = text
+            meta["last_event_type"] = "user"
+            continue
+        if mtype != "gemini":
+            continue
+        text = _gemini_message_text(msg).strip()
+        if text:
+            meta["last_assistant_text"] = text
+            meta.update(_extract_codex_summary_signals(text, pr_url_re))
+        meta["model"] = msg.get("model") or meta["model"]
+        meta["last_event_type"] = "assistant"
+        for call in msg.get("toolCalls") or []:
+            if not isinstance(call, dict):
+                continue
+            name = _gemini_tool_name(call)
+            detail = _gemini_tool_detail(call)
+            meta["pending_tool"] = name
+            meta["pending_file"] = detail[:80] if isinstance(detail, str) else None
+            cmd = _gemini_tool_command(call)
+            if cmd:
+                signals = _codex_command_signals(cmd)
+                if signals["edit"]:
+                    meta["has_edit"] = True
+                    meta["last_edit_pos"] = pos
+                if signals["commit"]:
+                    meta["has_commit"] = True
+                    meta["last_commit_pos"] = pos
+                if signals["push"]:
+                    meta["has_push"] = True
+                    meta["last_push_pos"] = pos
+                output = _gemini_tool_output(call)
+                if signals["pr"] and output:
+                    mp = pr_url_re.search(output)
+                    if mp:
+                        meta["tail_pr_number"] = int(mp.group(2))
+                        meta["tail_pr_url"] = (
+                            "https://github.com/" + mp.group(1) + "/pull/" + mp.group(2)
+                        )
+            if call.get("status") in ("success", "cancelled", "error"):
+                meta["pending_tool"] = None
+                meta["pending_file"] = None
+    if not meta["last_meaningful_ts"]:
+        meta["last_meaningful_ts"] = _iso_ts_epoch(data.get("lastUpdated")) or mtime
+    with _conv_meta_cache_lock:
+        _conv_meta_cache[str(path)] = meta
+        global _conv_meta_cache_dirty
+        _conv_meta_cache_dirty = True
+    return meta
+
+
+def _gemini_activity_fields_from_tail(tail, live):
+    fields = {
+        "sidecar_status": None,
+        "sidecar_has_writes": False,
+        "sidecar_tool": None,
+        "sidecar_file": None,
+        "sidecar_ts": 0,
+        "sidecar_in_flight": False,
+    }
+    if not live or not tail:
+        return fields
+    ts = tail.get("last_meaningful_ts") or 0
+    pending_tool = tail.get("pending_tool")
+    if pending_tool:
+        fields.update({
+            "sidecar_status": "active",
+            "sidecar_tool": pending_tool,
+            "sidecar_file": tail.get("pending_file"),
+            "sidecar_ts": ts,
+            "sidecar_in_flight": True,
+        })
+        return fields
+    if tail.get("last_event_type") in ("user", "assistant"):
+        fields.update({
+            "sidecar_status": "active",
+            "sidecar_tool": "Thinking",
+            "sidecar_file": None,
+            "sidecar_ts": ts,
+            "sidecar_in_flight": True,
+        })
+    return fields
+
+
+def _git_branch_for_cwd(cwd):
+    if not cwd or not Path(cwd).is_dir():
+        return ""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(cwd), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, timeout=2,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return ""
+    if out.returncode != 0:
+        return ""
+    branch = (out.stdout or "").strip()
+    return "" if branch == "HEAD" else branch
+
+
+def find_gemini_conversations(repo_path=None, include_old=True, repo_only=True, progress=None, limit=None):
+    paths = _gemini_chat_paths()
+    if not paths:
+        return []
+    repo_path_obj = None
+    if repo_only:
+        repo_path = resolve_repo_path(repo_path)
+        repo_path_obj = Path(repo_path)
+    try:
+        repo_pins = _load_repo_pins()
+    except Exception:
+        repo_pins = {}
+    try:
+        name_overrides = _load_session_name_overrides()
+    except Exception:
+        name_overrides = {}
+    try:
+        archived_set = set(_load_archived_conversations())
+    except Exception:
+        archived_set = set()
+    try:
+        verified_set = set(_load_verified_conversations())
+    except Exception:
+        verified_set = set()
+    try:
+        last_interactions = _load_last_interactions()
+    except Exception:
+        last_interactions = {}
+
+    cutoff = _session_scan_cutoff_ts(include_old)
+    max_rows = _session_scan_file_limit(include_old)
+    spawn_by_sid = _gemini_spawn_pid_by_session_id()
+    git_top_cache = {}
+    out = []
+    scanned = 0
+    for path in paths:
+        if limit and scanned >= int(limit):
+            break
+        data = _load_gemini_chat(path)
+        if not data:
+            continue
+        sid = data.get("sessionId") or ""
+        if not sid:
+            continue
+        scanned += 1
+        tail = _extract_gemini_tail_meta(path) or {}
+        cwd = tail.get("cwd") or _gemini_project_root_for_chat(path)
+        pinned = repo_pins.get(sid)
+        pinned_repo = False
+        if repo_only:
+            if pinned and pinned != repo_path:
+                continue
+            if pinned == repo_path:
+                pinned_repo = True
+            elif not _codex_cwd_matches_repo(cwd, repo_path_obj, git_top_cache):
+                continue
+        try:
+            st = path.stat()
+        except OSError:
+            continue
+        modified = tail.get("last_meaningful_ts") or _iso_ts_epoch(data.get("lastUpdated")) or st.st_mtime
+        freshness = max(modified, last_interactions.get(sid) or 0)
+        if not include_old and sid not in spawn_by_sid and cutoff > 0 and freshness < cutoff:
+            continue
+        if not include_old and max_rows > 0 and len(out) >= max_rows:
+            continue
+        first_message = (tail.get("first_message") or "").strip()
+        display_name = (
+            name_overrides.get(sid)
+            or (first_message[:80] if first_message else None)
+            or "Gemini session"
+        )
+        tail_worktree_path = tail.get("tail_worktree_path") or ""
+        effective_cwd = tail_worktree_path or cwd
+        try:
+            cwd_exists = bool(effective_cwd and Path(effective_cwd).is_dir())
+        except OSError:
+            cwd_exists = False
+        folder_path = pinned or cwd or effective_cwd or ""
+        folder_label = Path(folder_path).name if folder_path else "Gemini"
+        spawn_info = spawn_by_sid.get(sid) or {}
+        spawn_pid = spawn_info.get("pid")
+        spawn_alive = bool(spawn_info.get("alive"))
+        activity_tail = tail
+        if spawn_alive and spawn_info.get("log"):
+            stream_tail = _extract_gemini_stream_tail_meta(spawn_info.get("log"))
+            if stream_tail:
+                activity_tail = {**tail, **{k: v for k, v in stream_tail.items() if v not in (None, "", 0)}}
+        gemini_activity = _gemini_activity_fields_from_tail(activity_tail, spawn_alive)
+        branch = tail.get("tail_branch") or _git_branch_for_cwd(effective_cwd)
+        out.append({
+            "id": sid,
+            "session_id": sid,
+            "source": "gemini",
+            "engine": "gemini",
+            "timestamp": "",
+            "branch": branch,
+            "git_branch": branch,
+            "first_message": first_message[:200],
+            "display_name": display_name,
+            "name_overridden": bool(name_overrides.get(sid)),
+            "last_prompt": (tail.get("last_prompt") or "")[:200],
+            "size": st.st_size,
+            "modified": modified,
+            "modified_human": time.strftime("%Y-%m-%d %H:%M", time.localtime(modified)),
+            "mtime": modified,
+            "jsonl_path": str(path),
+            "folder_label": folder_label,
+            "folder_path": folder_path,
+            "session_cwd": effective_cwd,
+            "session_cwd_exists": cwd_exists,
+            "session_cwd_is_worktree": bool(
+                tail_worktree_path or (effective_cwd and (Path(effective_cwd) / ".git").is_file())
+            ),
+            "worktree_dirty": (
+                _worktree_dirty_cached(effective_cwd, modified) if effective_cwd else False
+            ),
+            "effective_branch": tail.get("tail_branch") or None,
+            "effective_kind": "worktree" if tail_worktree_path else None,
+            "has_edit": tail.get("has_edit", False),
+            "has_commit": tail.get("has_commit", False),
+            "has_push": tail.get("has_push", False),
+            "last_edit_pos": tail.get("last_edit_pos", 0),
+            "last_commit_pos": tail.get("last_commit_pos", 0),
+            "last_push_pos": tail.get("last_push_pos", 0),
+            "last_event_type": activity_tail.get("last_event_type") or tail.get("last_event_type"),
+            "pending_tool": activity_tail.get("pending_tool") or tail.get("pending_tool"),
+            "pending_file": activity_tail.get("pending_file") or tail.get("pending_file"),
+            "last_assistant_text": tail.get("last_assistant_text"),
+            "tail_issue_number": None,
+            "tail_pr_number": tail.get("tail_pr_number"),
+            "tail_pr_url": tail.get("tail_pr_url"),
+            "pr_state": None,
+            "session_state": _parse_session_state(tail.get("last_assistant_text")),
+            "archived": sid in archived_set,
+            "verified": sid in verified_set,
+            "pinned_repo": pinned_repo,
+            "last_interacted": last_interactions.get(sid),
+            "is_live": spawn_alive,
+            "spawn_pid": spawn_pid,
+            **gemini_activity,
+            "needs_approval": False,
+            "needs_approval_message": "",
+            "model": tail.get("model") or "",
+            "reasoning_effort": "",
+        })
+    _prime_pr_states(c.get("tail_pr_url") for c in out)
+    for c in out:
+        if c.get("tail_pr_url"):
+            c["pr_state"] = _get_pr_state(c["tail_pr_url"])
+    out.sort(key=lambda x: x.get("last_interacted") or x.get("modified") or 0, reverse=True)
+    if progress:
+        progress(
+            "gemini",
+            state="done",
+            count=len(out),
+            total=scanned,
+            detail=f"{len(out)} Gemini session card(s) ready.",
+        )
+    return out
+
+
+def _gemini_token_usage_from_message(msg):
+    tokens = msg.get("tokens") if isinstance(msg, dict) else {}
+    if not isinstance(tokens, dict):
+        return None
+    input_tokens = _codex_int(tokens.get("input"))
+    cached = _codex_int(tokens.get("cached"))
+    output = _codex_int(tokens.get("output"))
+    thoughts = _codex_int(tokens.get("thoughts"))
+    tool = _codex_int(tokens.get("tool"))
+    total = _codex_int(tokens.get("total"))
+    if not any((input_tokens, cached, output, thoughts, tool, total)):
+        return None
+    return {
+        "input_tokens": input_tokens,
+        "cached_input_tokens": cached,
+        "output_tokens": output,
+        "reasoning_output_tokens": thoughts,
+        "tool_tokens": tool,
+        "total_tokens": total,
+    }
+
+
+def _parse_gemini_conversation(session_id, after_line=0):
+    path = _resolve_gemini_chat_path(session_id)
+    data = _load_gemini_chat(path) if path else None
+    if not data:
+        return {"events": [], "last_line": 0}
+    events = []
+    line_num = 0
+    messages = data.get("messages") if isinstance(data.get("messages"), list) else []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        ts = msg.get("timestamp") or ""
+        mtype = msg.get("type")
+        if mtype == "user":
+            line_num += 1
+            if line_num > after_line:
+                text = _gemini_message_text(msg)
+                if text:
+                    events.append({"line": line_num, "ts": ts, "type": "user_text", "text": text, "images": []})
+            continue
+        if mtype != "gemini":
+            continue
+        text = _gemini_message_text(msg).strip()
+        if text:
+            line_num += 1
+            if line_num > after_line:
+                events.append({
+                    "line": line_num,
+                    "ts": ts,
+                    "type": "assistant",
+                    "message_id": msg.get("id") or f"gemini-{line_num}",
+                    "blocks": [{"kind": "text", "text": text}],
+                })
+        for call in msg.get("toolCalls") or []:
+            if not isinstance(call, dict):
+                continue
+            line_num += 1
+            if line_num > after_line:
+                detail = _gemini_tool_detail(call)
+                if isinstance(detail, str) and len(detail) > 200:
+                    detail = detail[:200] + "..."
+                events.append({
+                    "line": line_num,
+                    "ts": call.get("timestamp") or ts,
+                    "type": "assistant",
+                    "message_id": f"gemini-tool-{line_num}",
+                    "blocks": [{"kind": "tool_use", "name": _gemini_tool_name(call), "detail": detail or ""}],
+                })
+            output = _gemini_tool_output(call)
+            if output:
+                line_num += 1
+                if line_num > after_line:
+                    if len(output) > 800:
+                        output = output[:800] + "\n..."
+                    events.append({
+                        "line": line_num,
+                        "ts": call.get("timestamp") or ts,
+                        "type": "tool_result",
+                        "text": output,
+                        "tool_use_id": call.get("id", ""),
+                        "is_error": call.get("status") == "error",
+                    })
+        usage = _gemini_token_usage_from_message(msg)
+        if usage:
+            line_num += 1
+            if line_num > after_line:
+                events.append({
+                    "line": line_num,
+                    "ts": ts,
+                    "type": "result",
+                    "duration_ms": "?",
+                    "token_usage": usage,
+                })
+    return {"events": events, "last_line": line_num}
+
+
+def _extract_gemini_usage(session_id):
+    empty = {
+        "latest_input_tokens": 0,
+        "peak_input_tokens": 0,
+        "total_output_tokens": 0,
+        "total_input_tokens": 0,
+        "total_cache_creation_tokens": 0,
+        "total_cache_read_tokens": 0,
+        "model": "",
+        "context_limit": GEMINI_CONTEXT_LIMIT,
+        "cost_usd": 0.0,
+        "cost_breakdown_usd": {"input": 0.0, "cache_creation": 0.0,
+                               "cache_read": 0.0, "output": 0.0},
+    }
+    path = _resolve_gemini_chat_path(session_id)
+    data = _load_gemini_chat(path) if path else None
+    if not data:
+        return empty
+    latest = 0
+    peak = 0
+    total_in = 0
+    total_cached = 0
+    total_out = 0
+    model = ""
+    for msg in data.get("messages") or []:
+        if not isinstance(msg, dict) or msg.get("type") != "gemini":
+            continue
+        if msg.get("model"):
+            model = msg.get("model")
+        usage = _gemini_token_usage_from_message(msg)
+        if not usage:
+            continue
+        window = usage["input_tokens"]
+        if window:
+            latest = window
+            peak = max(peak, window)
+        total_cached += usage["cached_input_tokens"]
+        total_in += max(usage["input_tokens"] - usage["cached_input_tokens"], 0)
+        total_out += usage["output_tokens"] + usage["reasoning_output_tokens"] + usage.get("tool_tokens", 0)
+    return {
+        **empty,
+        "latest_input_tokens": latest,
+        "peak_input_tokens": peak,
+        "total_output_tokens": total_out,
+        "total_input_tokens": total_in,
+        "total_cache_read_tokens": total_cached,
+        "model": model,
+    }
+
+
+def _extract_gemini_timeline(session_id):
+    path = _resolve_gemini_chat_path(session_id)
+    data = _load_gemini_chat(path) if path else None
+    if not data:
+        return {"events": [], "total_turns": 0}
+    events = []
+    turn = 0
+    for msg in data.get("messages") or []:
+        if not isinstance(msg, dict) or msg.get("type") != "gemini":
+            continue
+        turn += 1
+        ts = msg.get("timestamp") or ""
+        for call in msg.get("toolCalls") or []:
+            if not isinstance(call, dict):
+                continue
+            cmd = _gemini_tool_command(call)
+            if not cmd:
+                continue
+            kind = None
+            subject = ""
+            if _TIMELINE_PR_CREATE_RE.search(cmd):
+                kind = "pr"
+                m = _TIMELINE_PR_TITLE_RE.search(cmd)
+                if m:
+                    subject = m.group(1)
+            elif _TIMELINE_PUSH_RE.search(cmd):
+                kind = "push"
+            elif _TIMELINE_COMMIT_RE.search(cmd):
+                kind = "commit"
+                m = _TIMELINE_COMMIT_MSG_RE.search(cmd)
+                if m:
+                    subject = m.group(1)
+            if not kind:
+                continue
+            output = _gemini_tool_output(call)
+            entry = {
+                "kind": kind,
+                "turn": turn,
+                "ts": call.get("timestamp") or ts,
+                "subject": subject,
+                "success": call.get("status") == "success",
+            }
+            if kind == "commit":
+                m = _TIMELINE_COMMIT_RESULT_RE.search(output)
+                if m:
+                    entry["sha"] = m.group(1)
+                    if not entry.get("subject"):
+                        entry["subject"] = m.group(2).strip()[:200]
+            elif kind == "pr":
+                m = _TIMELINE_PR_NUMBER_FROM_URL_RE.search(output)
+                if m:
+                    entry["pr_number"] = int(m.group(1))
+            events.append(entry)
+    return {"events": events, "total_turns": turn}
+
+
+def resume_session_gemini(session_id, text):
+    """Resume a Gemini session with a one-shot headless prompt."""
+    resolved = _resolve_gemini_bin()
+    if not resolved["available"]:
+        return {"ok": False, "error": resolved["reason"], "code": resolved.get("code")}
+    for s in _spawned_sessions:
+        if s.get("engine") == "gemini" and s.get("resumed_sid") == session_id:
+            try:
+                if s["proc"].poll() is None:
+                    return {
+                        "ok": False,
+                        "error": "Gemini is already running for this session; wait for it to finish before sending another prompt.",
+                        "pid": s.get("pid"),
+                        "via": "gemini-resume-busy",
+                    }
+            except Exception:
+                pass
+    cwd = find_session_cwd(session_id) or str(Path.cwd())
+    if not Path(cwd).is_dir():
+        cwd = str(Path.cwd())
+    timestamp = time.strftime("%Y%m%dT%H%M%S")
+    log_filename = f"resume-gemini-{session_id[:8]}-{timestamp}.log"
+    log_dir = repo_log_dir(_git_toplevel_for_existing_dir(cwd) or cwd)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / log_filename
+    cmd = [resolved["bin"], "--approval-mode", os.environ.get("CCC_GEMINI_APPROVAL_MODE", "yolo"),
+           "--output-format", "stream-json", "--resume", session_id]
+    model = os.environ.get("CCC_GEMINI_MODEL")
+    if model:
+        cmd.extend(["--model", model])
+    cmd.extend(["-p", text])
+    log_fh = open(log_path, "w")
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            cwd=cwd,
+            start_new_session=True,
+        )
+    except (FileNotFoundError, OSError) as e:
+        log_fh.close()
+        return {"ok": False, "error": str(e), "via": "gemini-resume"}
+    entry = {
+        "pid": proc.pid,
+        "name": f"resume-gemini-{session_id[:8]}",
+        "log": str(log_path),
+        "prompt": text[:200],
+        "started": timestamp,
+        "proc": proc,
+        "log_fh": log_fh,
+        "resumed_sid": session_id,
+        "fifo": None,
+        "stdin_fd": None,
+        "engine": "gemini",
+    }
+    _spawned_sessions.append(entry)
+    _record_spawn_to_registry(
+        pid=proc.pid,
+        name=entry["name"],
+        log_path=log_path,
+        cwd=cwd,
+        spawned_at=timestamp,
+        command_summary=text[:200],
+        fifo=None,
+        engine="gemini",
+    )
+    return {"ok": True, "pid": proc.pid, "log": str(log_path), "resumed": True, "via": "gemini-resume"}
+
+
+def spawn_session_gemini(prompt, name=None, cwd=None, repo_path=None, worktree=False):
+    """Spawn a headless Gemini CLI run and return tracking info."""
+    resolved = _resolve_gemini_bin()
+    if not resolved["available"]:
+        return {"ok": False, "error": resolved["reason"], "code": resolved.get("code")}
+    ctx = require_repo_context({"cwd": cwd, "repo_path": repo_path}, allow_session=False)
+    spawn_cwd = ctx["cwd"]
+    session_name = _slugify(name or prompt) or "unnamed"
+    timestamp = time.strftime("%Y%m%dT%H%M%S")
+    log_filename = f"spawn-gemini-{session_name}-{timestamp}.log"
+    log_dir = repo_log_dir(ctx["repo_path"])
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / log_filename
+    cmd = [
+        resolved["bin"],
+        "--approval-mode", os.environ.get("CCC_GEMINI_APPROVAL_MODE", "yolo"),
+        "--output-format", "stream-json",
+    ]
+    model = os.environ.get("CCC_GEMINI_MODEL")
+    if model:
+        cmd.extend(["--model", model])
+    if worktree:
+        cmd.extend(["--worktree", session_name])
+    cmd.extend(["-p", prompt])
+    log_fh = open(log_path, "w")
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            cwd=spawn_cwd,
+            start_new_session=True,
+        )
+    except (FileNotFoundError, OSError) as e:
+        log_fh.close()
+        return {"ok": False, "error": str(e), "via": "gemini-spawn"}
+    entry = {
+        "pid": proc.pid,
+        "name": session_name,
+        "log": str(log_path),
+        "prompt": prompt[:200],
+        "started": timestamp,
+        "proc": proc,
+        "log_fh": log_fh,
+        "fifo": None,
+        "stdin_fd": None,
+        "engine": "gemini",
+    }
+    _spawned_sessions.append(entry)
+    _record_spawn_to_registry(
+        pid=proc.pid,
+        name=session_name,
+        log_path=log_path,
+        cwd=spawn_cwd,
+        spawned_at=timestamp,
+        command_summary=prompt[:200],
+        fifo=None,
+        engine="gemini",
+    )
+    return {"ok": True, "pid": proc.pid, "name": session_name, "log": str(log_path)}
+
+
 def spawn_session(prompt, name=None, cwd=None, repo_path=None, worktree=False):
     """Spawn a headless Claude Code session and return tracking info.
 
@@ -8121,6 +9143,8 @@ def _find_live_spawn_entry_for_session(session_id):
         log = s.get("log")
         if s.get("engine") == "codex" and _extract_codex_thread_id_from_log(log) == session_id:
             return s
+        if s.get("engine") == "gemini" and _extract_gemini_session_id_from_log(log) == session_id:
+            return s
         if log and session_id in _log_session_ids(log):
             return s
     return None
@@ -8281,11 +9305,12 @@ def _record_spawn_to_registry(pid, name, log_path, cwd, spawned_at, command_summ
     """Append a freshly-spawned session to the on-disk registry. The
     session_id is filled in lazily by the reattach sweep (it isn't known
     at fork time — Claude emits it in the first stream-json event, Codex
-    emits it in its `--json` event stream).
+    emits it in its `--json` event stream, Gemini emits it in its init
+    stream-json event).
     The fifo path is persisted so a fresh CCC instance can reopen the
     write side after a restart and continue injecting messages (Claude
-    only — Codex exec is one-shot).
-    `engine` ("claude" or "codex") tells the boot-time reattach sweep
+    only — Codex/Gemini headless runs are one-shot).
+    `engine` ("claude", "codex", or "gemini") tells the boot-time reattach sweep
     which ps-grep to use and which JSONL ingestion path to skip."""
     entries = _load_spawn_registry()
     entries.append({
@@ -8320,9 +9345,10 @@ def _pid_is_engine_process(pid, engine):
     (any python process whose argv mentions the engine name would otherwise
     pass).
 
-    `engine` is one of "claude" or "codex" — the basename we expect at
-    argv[0]."""
-    if engine not in ("claude", "codex"):
+    `engine` is one of "claude", "codex", or "gemini" — the basename we expect
+    at argv[0] (Gemini's npm wrapper may appear as a node process whose argv
+    includes the gemini script path)."""
+    if engine not in ("claude", "codex", "gemini"):
         return False
     try:
         out = subprocess.run(
@@ -8339,7 +9365,11 @@ def _pid_is_engine_process(pid, engine):
     parts = cmd.split()
     if not parts:
         return False
-    return parts[0].rsplit("/", 1)[-1] == engine
+    if parts[0].rsplit("/", 1)[-1] == engine:
+        return True
+    if engine == "gemini":
+        return any(p.rsplit("/", 1)[-1] == "gemini" for p in parts[1:4])
+    return False
 
 
 def _reattach_spawned_orphans():
@@ -8399,6 +9429,11 @@ def _reattach_spawned_orphans():
         elif engine == "codex" and not session_id and log_path:
             try:
                 session_id = _extract_codex_thread_id_from_log(log_path)
+            except Exception:
+                session_id = None
+        elif engine == "gemini" and not session_id and log_path:
+            try:
+                session_id = _extract_gemini_session_id_from_log(log_path)
             except Exception:
                 session_id = None
         # Looks legit — re-add to the in-memory map with a stub proc.
@@ -8487,6 +9522,8 @@ def _inject_text_into_session(session_id, text):
         return {"ok": False, "error": "missing session_id or text"}
     if _is_codex_session(session_id):
         return resume_session_codex(session_id, text)
+    if _is_gemini_session(session_id):
+        return resume_session_gemini(session_id, text)
     cwd = find_session_cwd(session_id)
     status = session_live_status(session_id, cwd)
     tty = status.get("tty")
@@ -9773,6 +10810,8 @@ def _resolve_spawn_log_for_session(session_id):
             matches = True
         elif s.get("engine") == "codex":
             matches = _extract_codex_thread_id_from_log(log) == session_id
+        elif s.get("engine") == "gemini":
+            matches = _extract_gemini_session_id_from_log(log) == session_id
         else:
             matches = session_id in _log_session_ids(log)
         if matches:
@@ -9794,6 +10833,8 @@ def _resolve_spawn_log_for_session(session_id):
             if not matches:
                 if entry.get("engine") == "codex":
                     matches = _extract_codex_thread_id_from_log(log) == session_id
+                elif entry.get("engine") == "gemini":
+                    matches = _extract_gemini_session_id_from_log(log) == session_id
                 else:
                     sids_in_log = _log_session_ids(log)
                     matches = session_id in sids_in_log
@@ -9839,6 +10880,35 @@ def _normalize_spawn_event(ev):
     if not isinstance(ev, dict):
         return None
     t = ev.get("type")
+    if t == "message" and ev.get("role") == "assistant":
+        text = ev.get("content") or ""
+        if not text:
+            return None
+        return {
+            "type": "assistant_block",
+            "message_id": "gemini-stream",
+            "blocks": [{"type": "text", "text": text}],
+        }
+    if t == "tool_use":
+        params = ev.get("parameters") if isinstance(ev.get("parameters"), dict) else {}
+        summary = params.get("description") or params.get("command") or ""
+        return {
+            "type": "assistant_block",
+            "message_id": ev.get("tool_id") or "gemini-tool",
+            "blocks": [{
+                "type": "tool_use",
+                "name": ev.get("tool_name") or "tool",
+                "id": ev.get("tool_id") or "",
+                "summary": str(summary)[:160] if summary else "",
+            }],
+        }
+    if t == "result" and ("status" in ev or "stats" in ev):
+        return {
+            "type": "result",
+            "subtype": ev.get("status", ""),
+            "duration_ms": (ev.get("stats") or {}).get("duration_ms") if isinstance(ev.get("stats"), dict) else None,
+            "num_turns": None,
+        }
     if t == "assistant":
         msg = ev.get("message") or {}
         content = msg.get("content") or []
@@ -10659,6 +11729,8 @@ def extract_session_timeline(session_id):
     """
     if _is_codex_session(session_id):
         return _extract_codex_timeline(session_id)
+    if _is_gemini_session(session_id):
+        return _extract_gemini_timeline(session_id)
     if not PROJECTS_ROOT.is_dir():
         return {"events": [], "total_turns": 0}
     jsonl = None
@@ -10869,6 +11941,8 @@ def extract_session_usage(session_id):
     }
     if _is_codex_session(session_id):
         return _extract_codex_usage(session_id)
+    if _is_gemini_session(session_id):
+        return _extract_gemini_usage(session_id)
     desktop_meta = _load_desktop_app_metadata().get(session_id) or {}
     if not PROJECTS_ROOT.is_dir():
         return {**empty, "model": desktop_meta.get("model") or ""}
@@ -12263,6 +13337,11 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
             info = _resolve_codex_bin()
             info["model"] = os.environ.get("CCC_CODEX_MODEL", "gpt-5.5")
             self.send_json(info)
+        elif path == "/api/sessions/spawn-gemini/availability":
+            info = _resolve_gemini_bin()
+            info["model"] = os.environ.get("CCC_GEMINI_MODEL", "auto")
+            info["approval_mode"] = os.environ.get("CCC_GEMINI_APPROVAL_MODE", "yolo")
+            self.send_json(info)
         elif path == "/api/loading-status":
             self.send_json(_session_load_snapshot())
         elif path == "/api/sessions":
@@ -13472,6 +14551,62 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
                     self.send_json(e.as_payload(), e.status)
                 except Exception as e:
                     self.send_json({"ok": False, "error": str(e)}, 500)
+        elif path == "/api/sessions/spawn-gemini":
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length) if length > 0 else b""
+            try:
+                payload = json.loads(body) if body else {}
+            except json.JSONDecodeError:
+                payload = {}
+            prompt = (payload.get("prompt") or "").strip()
+            name = (payload.get("name") or "").strip() or None
+            cwd_raw = payload.get("cwd")
+            cwd_input = cwd_raw.strip() if isinstance(cwd_raw, str) else ""
+            cwd_resolved = None
+            cwd_error = None
+            if cwd_input:
+                try:
+                    expanded = os.path.expanduser(cwd_input)
+                    candidate = Path(expanded).resolve()
+                except (OSError, RuntimeError) as e:
+                    cwd_error = f"could not resolve path ({e})"
+                else:
+                    home = Path.home().resolve()
+                    try:
+                        st = os.stat(candidate)
+                    except OSError as e:
+                        cwd_error = f"path does not exist ({e.strerror or e})"
+                    else:
+                        if not stat.S_ISDIR(st.st_mode):
+                            cwd_error = f"not a directory: {candidate}"
+                        else:
+                            try:
+                                candidate.relative_to(home)
+                            except ValueError:
+                                cwd_error = f"path is outside $HOME ({home}): {candidate}"
+                            else:
+                                cwd_resolved = candidate
+            if not prompt:
+                self.send_json({"ok": False, "error": "missing prompt"}, 400)
+            elif cwd_error:
+                self.send_json({"ok": False, "error": f"invalid cwd: {cwd_error}"}, 400)
+            else:
+                try:
+                    result = spawn_session_gemini(
+                        prompt,
+                        name=name,
+                        cwd=str(cwd_resolved) if cwd_resolved else None,
+                        repo_path=payload.get("repo_path"),
+                        worktree=bool(payload.get("worktree")),
+                    )
+                    if result.get("code") == "gemini_unavailable":
+                        self.send_json(result, 503)
+                    else:
+                        self.send_json(result)
+                except RepoContextError as e:
+                    self.send_json(e.as_payload(), e.status)
+                except Exception as e:
+                    self.send_json({"ok": False, "error": str(e)}, 500)
         elif re.match(r"^/api/sessions/spawned/\d+/inject$", path):
             pid = int(path.split("/")[4])
             length = int(self.headers.get("Content-Length", "0"))
@@ -14619,6 +15754,31 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
 
     def _stream_conversation(self, conversation_id, after_line):
         """SSE endpoint for real-time conversation tailing."""
+        if _is_gemini_session(conversation_id):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.end_headers()
+            last_keepalive = time.time()
+            try:
+                while True:
+                    result = _parse_gemini_conversation(conversation_id, after_line=after_line)
+                    events = result.get("events") or []
+                    if events:
+                        after_line = result.get("last_line") or after_line
+                        payload = {"events": events, "last_line": after_line}
+                        self.wfile.write(f"data: {json.dumps(payload)}\n\n".encode())
+                        self.wfile.flush()
+                    now = time.time()
+                    if now - last_keepalive >= 5:
+                        self.wfile.write(b"event: keepalive\ndata: {}\n\n")
+                        self.wfile.flush()
+                        last_keepalive = now
+                    time.sleep(0.5)
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                pass
+            return
         filepath, parser = _resolve_conversation_reader(conversation_id)
         if not filepath.exists():
             self.send_json({"error": "Conversation not found"}, 404)

--- a/static/index.html
+++ b/static/index.html
@@ -1776,6 +1776,11 @@
     background: rgba(88, 166, 255, 0.10);
     border: 1px solid rgba(88, 166, 255, 0.42);
   }
+  .conv-engine-icon.gemini {
+    color: #7aa2ff;
+    background: rgba(122, 162, 255, 0.10);
+    border: 1px solid rgba(122, 162, 255, 0.42);
+  }
   .conv-signal {
     font-size: 10px; padding: 1px 5px; border-radius: 3px;
     font-weight: 600; white-space: nowrap; flex: 0 0 auto;
@@ -1812,6 +1817,7 @@
   .conv-signal.gh-link { background: rgba(139,148,158,0.12); color: var(--text-muted); font-weight: 600; }
   .conv-item .source-badge.pkood { background: rgba(210,153,34,0.2); color: var(--orange); }
   .conv-item .source-badge.codex { background: rgba(88,166,255,0.18); color: #79c0ff; }
+  .conv-item .source-badge.gemini { background: rgba(122,162,255,0.16); color: #9bb7ff; }
   .pkood-tail-output {
     white-space: pre-wrap; word-break: break-word; font-family: 'SF Mono',SFMono-Regular,Consolas,monospace;
     font-size: 13px; line-height: 1.5; padding: 16px 20px; color: var(--text);
@@ -4434,9 +4440,10 @@
                the Esc button (mutually exclusive — Esc only appears for live
                sessions, this only for `__new__`). updateInputBar() toggles
                visibility. -->
-          <select id="convInputEngineSelect" class="engine-select" title="Engine that spawns this new session — claude or codex" style="display:none;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:4px 6px;font-size:12px;">
+          <select id="convInputEngineSelect" class="engine-select" title="Engine that spawns this new session — claude, codex, or gemini" style="display:none;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:4px 6px;font-size:12px;">
             <option value="claude">claude</option>
             <option value="codex">codex</option>
+            <option value="gemini">gemini</option>
           </select>
           <button class="esc-btn" id="convEscBtn" title="Send Esc to terminal — cancels in-flight response (or kills a headless spawn)">Esc</button>
           <button class="send-btn" id="convSendBtn" title="Send to terminal">&gt;</button>
@@ -4453,9 +4460,10 @@
         <input type="text" class="kpt-search" id="kptSearch" placeholder="Search sessions...">
         <button id="kptRefreshBtn" title="Refresh data" aria-label="Refresh data">&#8634;</button>
         <input type="text" class="kpt-new-session" id="kptNewSession" placeholder="New session prompt...">
-        <select id="kptToolbarEngineSelect" title="Engine that spawns the new session — claude or codex" style="background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:4px 6px;font-size:12px;">
+        <select id="kptToolbarEngineSelect" title="Engine that spawns the new session — claude, codex, or gemini" style="background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:4px 6px;font-size:12px;">
           <option value="claude">claude</option>
           <option value="codex">codex</option>
+          <option value="gemini">gemini</option>
         </select>
         <button id="kptRunBtn" title="Run new session" aria-label="Run new session">Run</button>
         <button id="kptListViewBtn" title="Switch to list view" aria-label="Switch to list view">&#9783;</button>
@@ -4567,6 +4575,7 @@
           <select id="nsmEngineSelect" style="background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:2px 6px;font-size:12px;">
             <option value="claude">claude</option>
             <option value="codex">codex</option>
+            <option value="gemini">gemini</option>
           </select>
         </label>
         <label class="nsm-pkood" title="Spawn the session in a fresh git worktree (`feat/<slug>` branch) so it can't accidentally commit to main."><input type="checkbox" id="nsmWorktree"> 🌿 worktree</label>
@@ -5117,13 +5126,17 @@
   }
 
   function buildResumeCommand(sid, cwd, cwdExists) {
-    if (!cwd) return 'claude --resume ' + sid;
+    const engine = currentSession && currentSession.source;
+    const resumeCmd = engine === 'codex'
+      ? 'codex resume ' + sid
+      : (engine === 'gemini' ? 'gemini --resume ' + sid : 'claude --resume ' + sid);
+    if (!cwd) return resumeCmd;
     // Derive worktree branch from a `.claude/worktrees/...` path:
     // e.g. /Users/.../.claude/worktrees/claude-fix/issue-88 -> branch "claude-fix/issue-88"
     const wtMatch = cwd.match(/\/\.claude\/worktrees\/(.+)$/);
     const quotedCwd = shellQuote(cwd);
     if (cwdExists) {
-      return 'cd ' + quotedCwd + ' && claude --resume ' + sid;
+      return 'cd ' + quotedCwd + ' && ' + resumeCmd;
     }
     // Directory missing — try to recreate the worktree first, then resume.
     if (wtMatch) {
@@ -5133,9 +5146,9 @@
       const quotedBranch = shellQuote(branch);
       return '(cd ' + quotedRepo + ' && git worktree add ' + quotedCwd + ' ' + quotedBranch +
              ' 2>/dev/null || git worktree add ' + quotedCwd + ' -b ' + quotedBranch + ' origin/main)' +
-             ' && cd ' + quotedCwd + ' && claude --resume ' + sid;
+             ' && cd ' + quotedCwd + ' && ' + resumeCmd;
     }
-    return 'cd ' + quotedCwd + ' && claude --resume ' + sid;
+    return 'cd ' + quotedCwd + ' && ' + resumeCmd;
   }
 
   function resumeButtonsForActiveTab() { return []; }
@@ -5162,14 +5175,15 @@
 
   function launchTargetsForCurrentSession() {
     const isCodex = currentSession.source === 'codex';
+    const isGemini = currentSession.source === 'gemini';
     const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(currentSession.id || '');
     return [
       { id: 'terminal', label: 'Terminal', hint: 'default', disabled: false },
       {
         id: 'desktop',
         label: 'Claude Desktop',
-        hint: (!isCodex && isUuid) ? 'app' : 'Claude only',
-        disabled: isCodex || !isUuid,
+        hint: (!isCodex && !isGemini && isUuid) ? 'app' : 'Claude only',
+        disabled: isCodex || isGemini || !isUuid,
       },
       {
         id: 'codex',
@@ -5277,7 +5291,8 @@
     const sid = currentSession.id;
     const isPkood = currentSession.source === 'pkood';
     const isCodex = currentSession.source === 'codex';
-    if (!sid || isPkood || isCodex) {
+    const isGemini = currentSession.source === 'gemini';
+    if (!sid || isPkood || isCodex || isGemini) {
       $announceBtnConv.style.display = 'none';
       delete $announceBtnConv.dataset.sessionId;
       return;
@@ -5330,11 +5345,12 @@
     const sid = currentSession && currentSession.id;
     const isPkood = currentSession && currentSession.source === 'pkood';
     const isCodex = currentSession && currentSession.source === 'codex';
+    const isGemini = currentSession && currentSession.source === 'gemini';
     const repos = (typeof repoListState !== 'undefined' && repoListState.repos) || [];
     const currentCwd = (currentSession && currentSession.cwd) || '';
     let html = '';
     html += '<div class="com-section-label">Move to repo</div>';
-    if (!sid || isPkood || isCodex) {
+    if (!sid || isPkood || isCodex || isGemini) {
       html += '<div class="com-item com-current">No movable session selected</div>';
     } else if (!repos.length) {
       html += '<div class="com-item com-current">No known repos. Add one in the Repo picker.</div>';
@@ -5412,6 +5428,7 @@
     const sid = currentSession.id;
     const isPkood = currentSession.source === 'pkood';
     const isCodex = currentSession.source === 'codex';
+    const isGemini = currentSession.source === 'gemini';
     const canJump = live && liveStatus.tty && liveStatus.terminalApp;
     const canShowLaunch = !!sid && !isPkood;
 
@@ -5449,7 +5466,8 @@
       if (!btn) continue;
       if (canShowLaunch) {
         btn.style.display = 'inline-flex';
-        btn.title = isCodex ? 'Open a Terminal window and run codex resume' : 'Open a Terminal window and run claude --resume';
+        btn.title = isCodex ? 'Open a Terminal window and run codex resume'
+          : (isGemini ? 'Open a Terminal window and run gemini --resume' : 'Open a Terminal window and run claude --resume');
         btn.querySelector('.jump-label').textContent = 'Launch';
         renderLaunchChoiceMenu($launchChoiceMenuConv);
       } else {
@@ -5829,7 +5847,7 @@
   async function openInClaudeDesktop(ev) {
     const btn = ev && ev.currentTarget;
     if (!btn || !currentSession.id) return;
-    if (currentSession.source === 'codex') return;
+    if (currentSession.source === 'codex' || currentSession.source === 'gemini') return;
     const snapshot = actionButtonSnapshot(btn);
     btn.classList.add('opening');
     btn.disabled = true;
@@ -5917,6 +5935,7 @@
     if (!$convInputBar) return;
     const isPkood = currentSession.source === 'pkood';
     const isCodex = currentSession.source === 'codex';
+    const isGemini = currentSession.source === 'gemini';
     const live = liveStatus.live && liveStatus.tty;
     const isConvTab = activeTab === 'sessions';
     const hasSession = !!currentSession.id;
@@ -5953,6 +5972,9 @@
       } else if (isCodex) {
         $convTtyLabel.textContent = live ? (liveStatus.tty || 'codex') : 'codex';
         $convInput.placeholder = live ? 'Send to Codex terminal...' : 'Resume Codex and send...';
+      } else if (isGemini) {
+        $convTtyLabel.textContent = live ? (liveStatus.tty || 'gemini') : 'gemini';
+        $convInput.placeholder = live ? 'Send to Gemini terminal...' : 'Resume Gemini and send...';
       } else if (live) {
         $convTtyLabel.textContent = liveStatus.tty;
         $convInput.placeholder = 'Send to terminal...';
@@ -6932,8 +6954,9 @@
       modified: Date.now() / 1000, size: 0, branch: '',
       last_event_type: null, pending_tool: null, pending_file: null,
       name_overridden: false,
-      // Codex also gets a durable thread in ~/.codex; the log path is only
-      // a fallback while the thread row is materializing.
+      // Fire-and-watch engines also get durable engine-native sessions; the
+      // log path is only a fallback while the real row is materializing.
+      agent_log_path: (source === 'codex' || source === 'gemini') ? (logPath || null) : null,
       codex_log_path: source === 'codex' ? (logPath || null) : null,
     };
     pendingSpawns.set(pid, card);
@@ -6949,10 +6972,10 @@
     if (typeof selectConversation === 'function') {
       selectConversation(id);
     }
-    // Auto-cleanup after 30s for Claude placeholders. Codex placeholders
+    // Auto-cleanup after 30s for Claude placeholders. Fire-and-watch placeholders
     // stick around until the durable thread row appears, with the spawn log
     // as a fallback if the CLI exits before creating a thread.
-    if (source !== 'codex') {
+    if (source !== 'codex' && source !== 'gemini') {
       setTimeout(() => {
         if (pendingSpawns.has(pid)) {
           pendingSpawns.delete(pid);
@@ -9350,11 +9373,15 @@
         }
       }
       const isCodexRow = c.source === 'codex' || c.engine === 'codex';
+      const isGeminiRow = c.source === 'gemini' || c.engine === 'gemini';
       let sourceBadge = '';
       if (c.source === 'pkood') sourceBadge = '<span class="source-badge pkood">pkood</span>';
       else if (isCodexRow) sourceBadge = '<span class="source-badge codex">codex</span>';
+      else if (isGeminiRow) sourceBadge = '<span class="source-badge gemini">gemini</span>';
       const engineIcon = isCodexRow
         ? '<span class="conv-engine-icon codex" title="Codex session" aria-label="Codex session">C</span>'
+        : isGeminiRow
+          ? '<span class="conv-engine-icon gemini" title="Gemini session" aria-label="Gemini session">G</span>'
         : '';
       // Prefer "last interacted" (the user's last UI action) over "last
       // event" (which includes Claude's autonomous responses) so the row
@@ -9394,7 +9421,7 @@
       const _activityAge = c.sidecar_ts ? Math.max(0, Math.floor(Date.now() / 1000 - c.sidecar_ts)) : 9999;
       const _rowActivityTs = c.sidecar_ts || c.last_interacted || c.modified || 0;
       const _rowActivityAge = _rowActivityTs ? Math.max(0, Math.floor(Date.now() / 1000 - _rowActivityTs)) : 9999;
-      const _midTurn = c.last_event_type === 'assistant' || (isCodexRow && c.last_event_type === 'user');
+      const _midTurn = c.last_event_type === 'assistant' || ((isCodexRow || isGeminiRow) && c.last_event_type === 'user');
       const _isActiveSidecar = c.is_live && c.sidecar_status === 'active';
       const _knownActivityTool = c.sidecar_tool || c.pending_tool || '';
       const _hasLivePendingTool = c.is_live && !!c.pending_tool;
@@ -9413,7 +9440,7 @@
           ? ((c.sidecar_in_flight ? 'Currently running' : 'Last known tool') + ': ' + _knownActivityTool)
           : (c.gh_in_progress
               ? 'Linked GitHub issue is marked in progress'
-              : (isCodexRow ? 'Codex is working' : 'Agent is working'));
+              : (isCodexRow ? 'Codex is working' : (isGeminiRow ? 'Gemini is working' : 'Agent is working')));
         const wipLabel = _codexOpenTurn ? 'WIP' : (_knownActivityTool || 'WIP');
         signals += '<span class="conv-signal activity-working" title="' + escapeHtml(wipTitle) + '">' + escapeHtml(wipLabel) + '</span>';
       }
@@ -9538,7 +9565,7 @@
         : '';
 
       const groupedRowClass = opts.suppressFolderChip ? ' is-grouped-row' : '';
-      return '<div class="conv-item' + active + groupedRowClass + (isCodexRow ? ' is-codex' : '') + (c.pinned_repo ? ' is-repo-pinned' : '') + (c._historyMatch ? ' is-history-match' : '') + '" draggable="true" data-id="' + c.id + '" data-session-id="' + escapeHtml(c.session_id || c.id) + '">'
+      return '<div class="conv-item' + active + groupedRowClass + (isCodexRow ? ' is-codex' : '') + (isGeminiRow ? ' is-gemini' : '') + (c.pinned_repo ? ' is-repo-pinned' : '') + (c._historyMatch ? ' is-history-match' : '') + '" draggable="true" data-id="' + c.id + '" data-session-id="' + escapeHtml(c.session_id || c.id) + '">'
         + '<span class="drag-handle" data-role="drag">&#10495;</span>'
         + '<div class="conv-title-row">'
           + '<div class="conv-main-row">'
@@ -11314,7 +11341,10 @@
       };
     }
     const paneEl = document.querySelector(`.conv-pane[data-pane-id="${paneId}"]`);
-    if (paneEl) paneEl.classList.toggle('is-codex-session', source === 'codex');
+    if (paneEl) {
+      paneEl.classList.toggle('is-codex-session', source === 'codex');
+      paneEl.classList.toggle('is-gemini-session', source === 'gemini');
+    }
     if (source === 'backlog') {
       setCurrentSession(null, null, null, false, null);
     } else {
@@ -11373,14 +11403,16 @@
     if (!$convPanelInput) return;
     const isPkood = currentSession.source === 'pkood';
     const isCodex = currentSession.source === 'codex';
+    const isGemini = currentSession.source === 'gemini';
     const live = liveStatus.live && liveStatus.tty;
     const hasSession = !!currentSession.id;
     if (hasSession && kanbanView) {
       $convPanelInput.classList.add('visible');
-      if ($cpTtyLabel) $cpTtyLabel.textContent = isPkood ? 'pkood' : (isCodex ? (liveStatus.tty || 'codex') : (liveStatus.tty || (live ? '' : 'offline')));
+      if ($cpTtyLabel) $cpTtyLabel.textContent = isPkood ? 'pkood' : (isCodex ? (liveStatus.tty || 'codex') : (isGemini ? (liveStatus.tty || 'gemini') : (liveStatus.tty || (live ? '' : 'offline'))));
       if ($cpInput) {
         if (isPkood) $cpInput.placeholder = 'Send to pkood agent...';
         else if (isCodex) $cpInput.placeholder = live ? 'Send to Codex terminal...' : 'Resume Codex and send...';
+        else if (isGemini) $cpInput.placeholder = live ? 'Send to Gemini terminal...' : 'Resume Gemini and send...';
         else if (live) $cpInput.placeholder = 'Send to terminal...';
         else $cpInput.placeholder = 'Send to terminal (offline)...';
       }
@@ -11962,20 +11994,24 @@
       // Pre-swap (toolbar Run): spawn_pid is still 'tmp-...'. Show a
       // placeholder until the spawn POST returns and re-selects this card.
       const $view = getConvView();
-      $view.innerHTML = '<div class="empty-state" style="height:auto;padding:40px;">Spawning codex run…</div>';
+      const engine = card && card.source === 'gemini' ? 'gemini' : 'codex';
+      $view.innerHTML = '<div class="empty-state" style="height:auto;padding:40px;">Spawning ' + engine + ' run…</div>';
       return;
     }
     const $view = getConvView();
+    const engine = card.source === 'gemini' ? 'gemini' : 'codex';
     try {
       const res = await fetch('/api/sessions/spawned/' + encodeURIComponent(card.spawn_pid) + '/log?_=' + Date.now());
       const data = await res.json().catch(() => ({ ok: false, error: 'invalid JSON response' }));
       if (!data.ok) {
-        $view.innerHTML = '<div class="empty-state" style="height:auto;padding:40px;">Failed to load codex log: ' + escapeHtml(data.error || ('HTTP ' + res.status)) + '</div>';
+        $view.innerHTML = '<div class="empty-state" style="height:auto;padding:40px;">Failed to load ' + engine + ' log: ' + escapeHtml(data.error || ('HTTP ' + res.status)) + '</div>';
         stopCodexLogPoller();
         return;
       }
       const atBottom = $view.scrollHeight - $view.scrollTop - $view.clientHeight < 40;
-      $view.innerHTML = renderCodexLogHtml(data);
+      $view.innerHTML = (data.engine === 'gemini' || engine === 'gemini')
+        ? renderGeminiLogHtml(data)
+        : renderCodexLogHtml(data);
       if (atBottom) $view.scrollTop = $view.scrollHeight;
       // Process exited — stop polling. Final render already in place.
       if (!data.running) stopCodexLogPoller();
@@ -12051,6 +12087,69 @@
     return '<div class="codex-log" style="padding:16px 20px;">' + headerHtml + msgsHtml + usageHtml + stderrHtml + '</div>';
   }
 
+  function renderGeminiLogHtml(data) {
+    const lines = (data.text || '').split('\n').filter(Boolean);
+    const messages = [];
+    let usage = null;
+    let sessionId = '';
+    const stderrLines = [];
+    for (const line of lines) {
+      try {
+        const ev = JSON.parse(line);
+        if (ev.type === 'init' && ev.session_id) {
+          sessionId = ev.session_id;
+        } else if (ev.type === 'message' && ev.role === 'assistant' && ev.content) {
+          const last = messages[messages.length - 1];
+          if (last && last.role === 'assistant') last.text += ev.content;
+          else messages.push({ role: 'assistant', text: ev.content });
+        } else if (ev.type === 'tool_use') {
+          const params = ev.parameters || {};
+          const detail = params.description || params.command || '';
+          messages.push({ role: 'system', text: '[' + (ev.tool_name || 'tool') + (detail ? ': ' + detail : '') + ']' });
+        } else if (ev.type === 'tool_result') {
+          messages.push({ role: 'system', text: '[' + (ev.status || 'tool result') + ']' });
+        } else if (ev.type === 'result' && ev.stats) {
+          usage = ev.stats;
+        }
+      } catch (_) {
+        const text = (line || '').trim();
+        if (text && !/^YOLO mode is enabled\./.test(text) && text !== 'MCP issues detected. Run /mcp list for status.') {
+          stderrLines.push(line);
+        }
+      }
+    }
+    const status = data.running
+      ? '<span class="codex-status running" style="color:var(--green);">running</span>'
+      : ('<span class="codex-status finished" style="color:var(--text-muted);">finished' + (data.exit_code != null ? ' (exit ' + data.exit_code + ')' : '') + '</span>');
+    const usageHtml = usage
+      ? ('<div class="codex-usage" style="margin-top:12px;padding:8px 10px;background:rgba(139,148,158,0.08);border-radius:6px;font-size:12px;color:var(--text-muted);font-family:var(--font-mono,monospace);">'
+        + 'in ' + (usage.input_tokens || usage.input || 0)
+        + (usage.cached ? ' (' + usage.cached + ' cached)' : '')
+        + ' · out ' + (usage.output_tokens || 0)
+        + '</div>')
+      : '';
+    const msgsHtml = messages.length
+      ? messages.map(m => {
+          if (m.role === 'assistant') {
+            return '<div class="codex-msg assistant" style="margin-bottom:14px;padding:10px 12px;background:rgba(122,162,255,0.07);border-left:2px solid #7aa2ff;border-radius:4px;white-space:pre-wrap;line-height:1.55;">' + escapeHtml(m.text) + '</div>';
+          }
+          return '<div class="codex-msg system" style="margin-bottom:6px;font-size:12px;color:var(--text-muted);font-family:var(--font-mono,monospace);">' + escapeHtml(m.text) + '</div>';
+        }).join('')
+      : '<div class="empty-state" style="height:auto;padding:24px;color:var(--text-muted);">gemini is thinking…</div>';
+    const stderrHtml = stderrLines.length
+      ? ('<details style="margin-top:14px;font-size:12px;color:var(--text-muted);"><summary style="cursor:pointer;">gemini stderr (' + stderrLines.length + ' line' + (stderrLines.length === 1 ? '' : 's') + ')</summary>'
+        + '<pre style="margin:8px 0 0;padding:8px;background:rgba(139,148,158,0.08);border-radius:4px;white-space:pre-wrap;font-family:var(--font-mono,monospace);">' + escapeHtml(stderrLines.join('\n')) + '</pre>'
+        + '</details>')
+      : '';
+    const headerHtml = '<div class="codex-header" style="display:flex;align-items:center;gap:10px;padding-bottom:10px;margin-bottom:14px;border-bottom:1px solid var(--border);font-size:12px;color:var(--text-muted);">'
+      + '<span class="source-badge gemini" style="background:rgba(122,162,255,0.16);color:#9bb7ff;padding:2px 8px;border-radius:10px;font-weight:600;">gemini</span>'
+      + status
+      + (sessionId ? '<span style="font-family:var(--font-mono,monospace);">session ' + escapeHtml(sessionId.slice(0, 8)) + '…</span>' : '')
+      + '<span style="margin-left:auto;font-family:var(--font-mono,monospace);">pid ' + escapeHtml(String(data.pid)) + '</span>'
+      + '</div>';
+    return '<div class="codex-log gemini-log" style="padding:16px 20px;">' + headerHtml + msgsHtml + usageHtml + stderrHtml + '</div>';
+  }
+
   async function fetchConversationEvents(paneId) {
     if (paneId) {
       const idx = paneIndexByPaneId(paneId);
@@ -12076,7 +12175,7 @@
     // thread row appears in /api/sessions.
     if (id.startsWith('spawning-')) {
       const c = (conversationsData || []).find(x => x.id === id);
-      if (c && c.source === 'codex') {
+      if (c && (c.source === 'codex' || c.source === 'gemini')) {
         await loadCodexLog(c);
         stopCodexLogPoller();
         codexLogPoller = setInterval(() => {
@@ -15025,12 +15124,12 @@
   function getSpawnEngine() {
     try {
       const v = localStorage.getItem('ccc.spawnEngine');
-      if (v === 'claude' || v === 'codex') return v;
+      if (v === 'claude' || v === 'codex' || v === 'gemini') return v;
     } catch (_) {}
     return 'claude';
   }
   function setSpawnEngine(v) {
-    if (v !== 'claude' && v !== 'codex') return;
+    if (v !== 'claude' && v !== 'codex' && v !== 'gemini') return;
     try { localStorage.setItem('ccc.spawnEngine', v); } catch (_) {}
     // $nsmEngineSelect is declared further down in this script; by the
     // time any user interaction calls setSpawnEngine() it will exist.
@@ -15043,30 +15142,37 @@
     sel.value = getSpawnEngine();
     sel.addEventListener('change', () => setSpawnEngine(sel.value));
   });
-  // Probe Codex availability so a user with no Codex install sees the
+  // Probe alternate-engine availability so a user with no CLI install sees the
   // option greyed out instead of getting a 503 mid-spawn. Polled on
   // window focus too — handles "I just installed it; refresh the UI"
   // without a hard reload.
+  async function refreshEngineAvailability() {
+    async function probe(engine, endpoint, label) {
+      try {
+        const r = await fetch(endpoint);
+        const d = await r.json();
+        const reason = d.available ? '' : (d.reason || (label + ' CLI not found'));
+        const selectors = [$convInputEngineSelect, $kptToolbarEngineSelect,
+          (typeof $nsmEngineSelect !== 'undefined' ? $nsmEngineSelect : null)];
+        selectors.forEach(sel => {
+          const opt = sel && sel.querySelector('option[value="' + engine + '"]');
+          if (!opt) return;
+          opt.disabled = !d.available;
+          opt.title = reason;
+          opt.textContent = d.available ? engine : (engine + ' (unavailable)');
+        });
+        if (!d.available && getSpawnEngine() === engine) setSpawnEngine('claude');
+      } catch (_) {}
+    }
+    await Promise.all([
+      probe('codex', '/api/sessions/spawn-codex/availability', 'Codex'),
+      probe('gemini', '/api/sessions/spawn-gemini/availability', 'Gemini'),
+    ]);
+  }
   async function refreshCodexAvailability() {
     try {
-      const r = await fetch('/api/sessions/spawn-codex/availability');
-      const d = await r.json();
-      const reason = d.available ? '' : (d.reason || 'Codex CLI not found');
-      const selectors = [$convInputEngineSelect, $kptToolbarEngineSelect,
-        (typeof $nsmEngineSelect !== 'undefined' ? $nsmEngineSelect : null)];
-      selectors.forEach(sel => {
-        const opt = sel && sel.querySelector('option[value="codex"]');
-        if (!opt) return;
-        opt.disabled = !d.available;
-        opt.title = reason;
-        opt.textContent = d.available ? 'codex' : 'codex (unavailable)';
-      });
-      // If the user had codex selected but it's no longer available,
-      // fall back to claude so the next spawn doesn't 503.
-      if (!d.available && getSpawnEngine() === 'codex') setSpawnEngine('claude');
-    } catch (_) {
-      // Probe is best-effort; a network blip shouldn't disable the dropdown.
-    }
+      await refreshEngineAvailability();
+    } catch (_) {}
   }
   refreshCodexAvailability();
   window.addEventListener('focus', refreshCodexAvailability);
@@ -15274,10 +15380,11 @@
       // placeholder only materialized after /api/sessions/spawn responded.
       const subject = prompt.length > 60 ? prompt.slice(0, 60) + '…' : prompt;
       const tempPid = 'tmp-' + Date.now();
-      // Source for the optimistic card: 'codex' renders the codex chip
-      // (Task 9); 'pkood' keeps the orange pkood chip; 'claude' uses
+      // Source for the optimistic card: alternate engines render their chip;
+      // 'pkood' keeps the orange pkood chip; 'claude' uses
       // 'interactive' (no chip).
       const cardSource = engine === 'codex' ? 'codex'
+                       : engine === 'gemini' ? 'gemini'
                        : engine === 'pkood' ? 'pkood'
                        : 'interactive';
       insertPendingSpawnCard(tempPid, subject, cardSource);
@@ -15286,9 +15393,10 @@
       try {
         const endpoint = engine === 'pkood' ? '/api/pkood/spawn'
                        : engine === 'codex' ? '/api/sessions/spawn-codex'
+                       : engine === 'gemini' ? '/api/sessions/spawn-gemini'
                        : '/api/sessions/spawn';
         // pkood and codex don't support the worktree flag — drop it for those.
-        const body = engine === 'claude'
+        const body = (engine === 'claude' || engine === 'gemini')
           ? { prompt, repo_path: repoPath, worktree: useWorktree }
           : { prompt, repo_path: repoPath };
         const res = await fetch(endpoint, {
@@ -15308,9 +15416,9 @@
             const placeholder = conversationsData.find(x => x.id === 'spawning-' + tempPid);
             if (placeholder) {
               placeholder.spawn_pid = data.pid;
-              // Codex spawns are fire-and-watch; stash the log path so the
+              // Fire-and-watch engines stash the log path so the
               // right-pane renderer can fetch /api/sessions/spawned/<pid>/log.
-              if (engine === 'codex' && data.log) placeholder.codex_log_path = data.log;
+              if ((engine === 'codex' || engine === 'gemini') && data.log) placeholder.agent_log_path = data.log;
               pendingSpawns.delete(tempPid);
               pendingSpawns.set(data.pid, placeholder);
             }
@@ -15320,10 +15428,10 @@
           setTimeout(refreshConversationList, 600);
           setTimeout(refreshConversationList, 1500);
           setTimeout(refreshConversationList, 3000);
-          // If the user picked codex, refocus the right pane on the
-          // placeholder so renderCodexPlaceholder kicks in for the new pid
+          // If the user picked a fire-and-watch engine, refocus the right pane on the
+          // placeholder so log rendering kicks in for the new pid
           // (the auto-select fired when tempPid was still in play).
-          if (engine === 'codex' && typeof selectConversation === 'function') {
+          if ((engine === 'codex' || engine === 'gemini') && typeof selectConversation === 'function') {
             selectConversation('spawning-' + tempPid);
           }
         } else {
@@ -15401,7 +15509,8 @@
     $nsmSubmit.textContent = 'Launching...';
     try {
       const endpoint = engine === 'codex' ? '/api/sessions/spawn-codex'
-                                          : '/api/sessions/spawn';
+                     : engine === 'gemini' ? '/api/sessions/spawn-gemini'
+                     : '/api/sessions/spawn';
       const body = engine === 'codex'
         ? { prompt, name: effectiveSubject, repo_path: repoPath }
         : { prompt, name: effectiveSubject, repo_path: repoPath, worktree: useWorktree };
@@ -15412,7 +15521,9 @@
       const data = await res.json().catch(() => ({ ok: false, error: 'invalid JSON response' }));
       if (data.ok) {
         closeNewSessionModal();
-        const cardSource = engine === 'codex' ? 'codex' : 'interactive';
+        const cardSource = engine === 'codex' ? 'codex'
+                         : engine === 'gemini' ? 'gemini'
+                         : 'interactive';
         insertPendingSpawnCard(data.pid, effectiveSubject, cardSource);
         // Tight poll schedule so the real card replaces the placeholder fast.
         setTimeout(refreshConversationList, 600);
@@ -15526,7 +15637,7 @@
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({ agent_id: agentId, message: text }),
           });
-        } else if (currentSession.spawnPid && currentSession.source !== 'codex') {
+        } else if (currentSession.spawnPid && currentSession.source !== 'codex' && currentSession.source !== 'gemini') {
           // Headless session we spawned — push via stdin pipe
           res = await fetch('/api/sessions/spawned/' + currentSession.spawnPid + '/inject', {
             method: 'POST',
@@ -16327,7 +16438,8 @@
     const spawnCwd = getSpawnCwd();
     const $view = getConvView();
     if ($view) {
-      const engineLabel = getSpawnEngine() === 'codex' ? 'Codex' : 'Claude';
+      const spawnEngine = getSpawnEngine();
+      const engineLabel = spawnEngine === 'codex' ? 'Codex' : (spawnEngine === 'gemini' ? 'Gemini' : 'Claude');
       const repoLabel = selectedRepoLabel() || _pathLeaf(spawnCwd) || spawnCwd || 'pick a folder below';
       $view.innerHTML = '<div class="empty-state" style="height:auto;padding:48px 32px;flex-direction:column;gap:10px;text-align:center;">'
         + '<div style="font-size:16px;color:var(--text);">Start a new session</div>'
@@ -16436,7 +16548,8 @@
     };
     try {
       const endpoint = engine === 'codex' ? '/api/sessions/spawn-codex'
-                                          : '/api/sessions/spawn';
+                     : engine === 'gemini' ? '/api/sessions/spawn-gemini'
+                     : '/api/sessions/spawn';
       const spawnBody = { prompt, name: subject, repo_path: repoPath, cwd: repoPath };
       const res = await fetch(endpoint, {
         method: 'POST', headers: {'Content-Type': 'application/json'},
@@ -16444,7 +16557,7 @@
       });
       const data = await res.json().catch(() => ({ ok: false, error: 'invalid JSON response' }));
       if (data.ok) {
-        insertPendingSpawnCard(data.pid, subject, engine === 'codex' ? 'codex' : 'interactive', data.log);
+        insertPendingSpawnCard(data.pid, subject, engine === 'codex' ? 'codex' : (engine === 'gemini' ? 'gemini' : 'interactive'), data.log);
         if ($convInput) $convInput.value = '';
         const $view = getConvView();
         if ($view) {

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -236,6 +236,17 @@ class TestRepoContextHelpers(unittest.TestCase):
         sig = inspect.signature(server.spawn_session_codex)
         self.assertEqual(list(sig.parameters), ["prompt", "name", "cwd", "repo_path"])
 
+    def test_spawn_session_gemini_exists(self):
+        """`spawn_session_gemini` must exist alongside the other engines
+        and accept explicit cwd/repo context."""
+        for mod in ("server", "morning", "morning_store"):
+            sys.modules.pop(mod, None)
+        server = importlib.import_module("server")
+        self.assertTrue(hasattr(server, "spawn_session_gemini"))
+        import inspect
+        sig = inspect.signature(server.spawn_session_gemini)
+        self.assertEqual(list(sig.parameters), ["prompt", "name", "cwd", "repo_path", "worktree"])
+
     def test_record_spawn_to_registry_persists_engine(self):
         """The on-disk spawn registry must round-trip an `engine` field
         so a CCC restart can branch claude-vs-codex reattach logic."""
@@ -258,9 +269,9 @@ class TestRepoContextHelpers(unittest.TestCase):
             finally:
                 server.SPAWNED_PIDS_FILE = orig
 
-    def test_pid_is_engine_process_recognises_codex(self):
+    def test_pid_is_engine_process_recognises_codex_and_gemini(self):
         """`_pid_is_engine_process` must accept an `engine` arg and match
-        the right argv[0] basename for it (`claude` or `codex`)."""
+        the right argv[0] basename for it."""
         for mod in ("server", "morning", "morning_store"):
             sys.modules.pop(mod, None)
         server = importlib.import_module("server")
@@ -275,6 +286,8 @@ class TestRepoContextHelpers(unittest.TestCase):
                     r.stdout = "/usr/local/bin/claude -p --verbose\n"
                 elif pid == "22222":
                     r.stdout = "/Applications/Codex.app/Contents/Resources/codex exec --json\n"
+                elif pid == "33333":
+                    r.stdout = "/usr/local/bin/node /usr/local/bin/gemini --output-format stream-json\n"
             return r
 
         with mock.patch.object(server.subprocess, "run", side_effect=fake_run):
@@ -282,6 +295,106 @@ class TestRepoContextHelpers(unittest.TestCase):
             self.assertFalse(server._pid_is_engine_process(11111, "codex"))
             self.assertTrue(server._pid_is_engine_process(22222, "codex"))
             self.assertFalse(server._pid_is_engine_process(22222, "claude"))
+            self.assertTrue(server._pid_is_engine_process(33333, "gemini"))
+            self.assertFalse(server._pid_is_engine_process(33333, "codex"))
+
+    def test_gemini_chat_parsing_usage_and_row_signals(self):
+        """Gemini chat JSON should render as a first-class session row."""
+        for mod in ("server",):
+            sys.modules.pop(mod, None)
+        import server
+
+        sid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        chat = {
+            "sessionId": sid,
+            "startTime": "2026-05-04T01:00:00.000Z",
+            "lastUpdated": "2026-05-04T01:02:00.000Z",
+            "kind": "main",
+            "messages": [
+                {
+                    "id": "u1",
+                    "timestamp": "2026-05-04T01:00:00.000Z",
+                    "type": "user",
+                    "content": [{"text": "Create the probe file."}],
+                },
+                {
+                    "id": "g1",
+                    "timestamp": "2026-05-04T01:01:00.000Z",
+                    "type": "gemini",
+                    "content": "I created and committed the probe.",
+                    "model": "gemini-test-model",
+                    "tokens": {
+                        "input": 1200,
+                        "output": 30,
+                        "cached": 200,
+                        "thoughts": 5,
+                        "tool": 0,
+                        "total": 1235,
+                    },
+                    "toolCalls": [{
+                        "id": "run_shell_command_1",
+                        "name": "run_shell_command",
+                        "args": {
+                            "command": "printf 'ok\\n' > probe.txt && git add probe.txt && git commit -m \"probe: gemini\"",
+                            "description": "Create and commit probe file.",
+                        },
+                        "status": "success",
+                        "timestamp": "2026-05-04T01:01:10.000Z",
+                        "result": [{
+                            "functionResponse": {
+                                "response": {
+                                    "output": "Output: [feat/demo abc1234] probe: gemini\n 1 file changed, 1 insertion(+)"
+                                }
+                            }
+                        }],
+                    }],
+                },
+                {
+                    "id": "g2",
+                    "timestamp": "2026-05-04T01:02:00.000Z",
+                    "type": "gemini",
+                    "content": "Branch: feat/demo\nCommit: abc1234 probe: gemini\nWorktree: /tmp/example-worktree",
+                    "model": "gemini-test-model",
+                    "tokens": {
+                        "input": 1300,
+                        "output": 20,
+                        "cached": 250,
+                        "thoughts": 4,
+                        "tool": 0,
+                        "total": 1324,
+                    },
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            gemini_home = pathlib.Path(tmp) / ".gemini"
+            project = gemini_home / "tmp" / "example-project"
+            chats = project / "chats"
+            chats.mkdir(parents=True)
+            (project / ".project_root").write_text("/tmp/example-repo")
+            chat_path = chats / "session-2026-05-04T01-00-aaaaaaaa.json"
+            chat_path.write_text(json.dumps(chat))
+            orig_home = server.GEMINI_HOME
+            server.GEMINI_HOME = gemini_home
+            try:
+                self.assertTrue(server._is_gemini_session(sid))
+                parsed = server.parse_conversation(sid)
+                usage = server.extract_session_usage(sid)
+                rows = server.find_gemini_conversations(include_old=True, repo_only=False)
+            finally:
+                server.GEMINI_HOME = orig_home
+
+        self.assertGreaterEqual(len(parsed["events"]), 4)
+        self.assertEqual(usage["latest_input_tokens"], 1300)
+        self.assertEqual(usage["total_cache_read_tokens"], 450)
+        self.assertEqual(usage["model"], "gemini-test-model")
+        row = rows[0]
+        self.assertEqual(row["source"], "gemini")
+        self.assertTrue(row["has_edit"])
+        self.assertTrue(row["has_commit"])
+        self.assertEqual(row["effective_branch"], "feat/demo")
+        self.assertEqual(row["session_cwd"], "/tmp/example-worktree")
 
     def test_reattach_spawned_orphans_defaults_legacy_rows_to_claude(self):
         """A registry row written before the `engine` field existed


### PR DESCRIPTION
## Summary
- Adds Gemini CLI as a third session engine alongside Claude and Codex.
- Surfaces Gemini chat files as session rows with activity, tool, PR, usage, timeline, and log views.
- Adds Gemini spawn/resume endpoints, availability checks, registry persistence, and UI engine selection.

## Notes
- Rebased onto current main and aligned Gemini spawn with the repo-scoped `repo_path` API contract.

## Tests
- `python3 -m unittest discover -s tests`