### PR TITLE
feat: one-command install (curl | sh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ Requirements: macOS, Python 3, and [Claude Code](https://docs.claude.com/en/docs
 Optional: [`gh`](https://cli.github.com/) for GitHub integration, `vercel` for deploy status.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/amirfish1/claude-command-center/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/amirfish1/claude-command-center/main/scripts/install.sh | CCC_FROM=readme bash
 ```
 
 The installer clones to `~/.ccc/claude-command-center`, verifies your
 `python3` and `claude` CLI, and launches the dashboard in the foreground.
 Re-running the same command does a `git pull` instead of a second clone.
+
+If you'd rather clone first and run the script directly, pass the channel as a flag instead: `./scripts/install.sh --from=readme`.
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Requirements: macOS, Python 3, and [Claude Code](https://docs.claude.com/en/docs
 Optional: [`gh`](https://cli.github.com/) for GitHub integration, `vercel` for deploy status.
 
 ```bash
+curl -fsSL https://raw.githubusercontent.com/amirfish1/claude-command-center/main/scripts/install.sh | bash
+```
+
+The installer clones to `~/.ccc/claude-command-center`, verifies your
+`python3` and `claude` CLI, and launches the dashboard in the foreground.
+Re-running the same command does a `git pull` instead of a second clone.
+
+### From source
+
+```bash
 git clone https://github.com/amirfish1/claude-command-center
 cd claude-command-center
 

--- a/changelog.d/added-curl-install-2026-05-19.md
+++ b/changelog.d/added-curl-install-2026-05-19.md
@@ -1,0 +1,1 @@
+- One-command install: pipe `scripts/install.sh` into bash to clone, verify prereqs, and launch the dashboard on port 8090.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,9 +2,9 @@
 # Claude Command Center one-command installer.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/amirfish1/claude-command-center/main/scripts/install.sh | bash
-#   curl -fsSL ".../install.sh?from=hn" | bash
-#   ./install.sh --from=readme
+#   curl -fsSL https://raw.githubusercontent.com/amirfish1/claude-command-center/main/scripts/install.sh | CCC_FROM=hn bash
+#   curl -fsSL .../install.sh | bash               # channel defaults to unknown
+#   ./install.sh --from=readme                     # direct invocation after git clone
 #
 # Behaviour:
 #   - macOS only. Linux exits fast with a one-line pointer to the Docker issue.
@@ -31,15 +31,18 @@ err() {
 # ---------------------------------------------------------------------------
 # Attribution channel
 # ---------------------------------------------------------------------------
-# Parsed from either:
-#   - a query string on $0 (when curled like ".../install.sh?from=hn | bash"
-#     some shells preserve the URL in $0; we look defensively)
-#   - --from=<channel> argv
+# Resolution order (highest precedence first):
+#   1. --from=<channel> CLI flag (for direct ./install.sh invocation)
+#   2. CCC_FROM env var (for `curl ... | CCC_FROM=hn bash` pipe invocation)
+#   3. default 'unknown'
+#
+# We can't recover the URL from $0 under `curl ... | bash` because bash sets
+# $0 to "bash" or "-", not the source URL. Hence the env-var hand-off.
 parse_channel() {
   local raw=""
-  case "${0:-}" in
-    *\?from=*) raw="${0#*\?from=}"; raw="${raw%%[&# ]*}" ;;
-  esac
+  if [ -n "${CCC_FROM:-}" ]; then
+    raw="$CCC_FROM"
+  fi
   for arg in "$@"; do
     case "$arg" in
       --from=*) raw="${arg#--from=}" ;;
@@ -158,4 +161,8 @@ main() {
   launch_server
 }
 
-main "$@"
+# Only auto-run when executed, not when sourced (tests source us for
+# direct `parse_channel` calls).
+if [ "${BASH_SOURCE[0]:-$0}" = "${0}" ]; then
+  main "$@"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Claude Command Center one-command installer.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/amirfish1/claude-command-center/main/scripts/install.sh | bash
+#   curl -fsSL ".../install.sh?from=hn" | bash
+#   ./install.sh --from=readme
+#
+# Behaviour:
+#   - macOS only. Linux exits fast with a one-line pointer to the Docker issue.
+#   - Clones to ~/.ccc/claude-command-center if absent, git pulls if present.
+#   - Verifies python3 and the `claude` CLI are on PATH.
+#   - Persists an attribution channel to ~/.claude/command-center/install-source.
+#   - Launches ./run.sh in the foreground and opens http://localhost:8090
+#     once the port answers.
+
+set -euo pipefail
+
+REPO_URL="https://github.com/amirfish1/claude-command-center"
+INSTALL_DIR="$HOME/.ccc/claude-command-center"
+PORT="${PORT:-8090}"
+DASHBOARD_URL="http://localhost:${PORT}"
+SOURCE_FILE="$HOME/.claude/command-center/install-source"
+
+VALID_CHANNELS="readme landing-hero hn ph devto yt gh-trending unknown"
+
+err() {
+  printf 'install: %s\n' "$*" >&2
+}
+
+# ---------------------------------------------------------------------------
+# Attribution channel
+# ---------------------------------------------------------------------------
+# Parsed from either:
+#   - a query string on $0 (when curled like ".../install.sh?from=hn | bash"
+#     some shells preserve the URL in $0; we look defensively)
+#   - --from=<channel> argv
+parse_channel() {
+  local raw=""
+  case "${0:-}" in
+    *\?from=*) raw="${0#*\?from=}"; raw="${raw%%[&# ]*}" ;;
+  esac
+  for arg in "$@"; do
+    case "$arg" in
+      --from=*) raw="${arg#--from=}" ;;
+    esac
+  done
+  if [ -z "$raw" ]; then
+    printf 'unknown'
+    return
+  fi
+  for valid in $VALID_CHANNELS; do
+    if [ "$raw" = "$valid" ]; then
+      printf '%s' "$valid"
+      return
+    fi
+  done
+  printf 'unknown'
+}
+
+persist_channel() {
+  local channel="$1"
+  local dir
+  dir="$(dirname "$SOURCE_FILE")"
+  mkdir -p "$dir"
+  printf '%s\n' "$channel" > "$SOURCE_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Platform gate
+# ---------------------------------------------------------------------------
+require_macos() {
+  local uname_s
+  uname_s="$(uname -s 2>/dev/null || printf 'unknown')"
+  if [ "$uname_s" != "Darwin" ]; then
+    err "CCC is macOS-only; see the Docker issue ${REPO_URL}/issues/54 once it ships"
+    exit 2
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Prereq checks
+# ---------------------------------------------------------------------------
+require_python3() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    err "python3 not found on PATH. Install Xcode CLT: xcode-select --install"
+    exit 1
+  fi
+}
+
+require_claude_cli() {
+  if ! command -v claude >/dev/null 2>&1; then
+    err "claude CLI not found on PATH. Install from https://docs.claude.com/en/docs/claude-code"
+    exit 1
+  fi
+}
+
+require_git() {
+  if ! command -v git >/dev/null 2>&1; then
+    err "git not found on PATH. Install Xcode CLT: xcode-select --install"
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Fetch / update repo
+# ---------------------------------------------------------------------------
+sync_repo() {
+  if [ -d "$INSTALL_DIR/.git" ]; then
+    printf 'install: updating existing checkout at %s\n' "$INSTALL_DIR"
+    git -C "$INSTALL_DIR" pull --ff-only
+  else
+    printf 'install: cloning %s to %s\n' "$REPO_URL" "$INSTALL_DIR"
+    mkdir -p "$(dirname "$INSTALL_DIR")"
+    git clone "$REPO_URL" "$INSTALL_DIR"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Launch + open browser
+# ---------------------------------------------------------------------------
+open_when_ready() {
+  # Background watcher: poll the port, then `open` the URL.
+  # Bounded by ~60 seconds so we never wedge if the server fails to start.
+  (
+    for _ in $(seq 1 60); do
+      if (echo > "/dev/tcp/127.0.0.1/${PORT}") >/dev/null 2>&1; then
+        open "$DASHBOARD_URL" >/dev/null 2>&1 || true
+        exit 0
+      fi
+      sleep 1
+    done
+  ) &
+}
+
+launch_server() {
+  printf 'install: launching ./run.sh on port %s\n' "$PORT"
+  open_when_ready
+  cd "$INSTALL_DIR"
+  exec ./run.sh
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+  require_macos
+  require_git
+  require_python3
+  require_claude_cli
+
+  local channel
+  channel="$(parse_channel "$@")"
+  persist_channel "$channel"
+  printf 'install: attribution channel = %s\n' "$channel"
+
+  sync_repo
+  launch_server
+}
+
+main "$@"

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,0 +1,58 @@
+"""Smoke tests for scripts/install.sh.
+
+The bar matches `tests/test_smoke.py`: existence, executable bit, sane
+shebang, optional shellcheck pass. We don't exercise the script end-to-end
+because it clones a repo, hits the network, and launches a server — too
+heavy for a smoke test.
+"""
+import os
+import shutil
+import stat
+import subprocess
+import unittest
+
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+INSTALL_SCRIPT = os.path.join(PROJECT_ROOT, "scripts", "install.sh")
+
+
+class TestInstallScript(unittest.TestCase):
+    def test_install_script_exists(self):
+        self.assertTrue(
+            os.path.isfile(INSTALL_SCRIPT),
+            "scripts/install.sh must exist",
+        )
+
+    def test_install_script_is_executable(self):
+        mode = os.stat(INSTALL_SCRIPT).st_mode
+        self.assertTrue(
+            mode & stat.S_IXUSR,
+            "scripts/install.sh must have the executable bit set",
+        )
+
+    def test_install_script_has_bash_shebang(self):
+        with open(INSTALL_SCRIPT, "rb") as fh:
+            first_line = fh.readline().rstrip(b"\n").decode("utf-8", "replace")
+        self.assertIn(
+            first_line,
+            ("#!/usr/bin/env bash", "#!/bin/bash"),
+            f"unexpected shebang: {first_line!r}",
+        )
+
+    def test_install_script_passes_shellcheck_when_available(self):
+        if shutil.which("shellcheck") is None:
+            self.skipTest("shellcheck not installed; skipping lint check")
+        result = subprocess.run(
+            ["shellcheck", INSTALL_SCRIPT],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"shellcheck failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,9 +1,10 @@
 """Smoke tests for scripts/install.sh.
 
 The bar matches `tests/test_smoke.py`: existence, executable bit, sane
-shebang, optional shellcheck pass. We don't exercise the script end-to-end
-because it clones a repo, hits the network, and launches a server — too
-heavy for a smoke test.
+shebang, optional shellcheck pass. We don't exercise the full script
+end-to-end (it clones a repo and launches a server), but we do exercise
+``parse_channel`` directly so attribution wiring can't silently regress —
+see the `CCC_FROM` / `--from=<channel>` resolution tests below.
 """
 import os
 import shutil
@@ -14,6 +15,43 @@ import unittest
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 INSTALL_SCRIPT = os.path.join(PROJECT_ROOT, "scripts", "install.sh")
+
+
+def _run_parse_channel(env_extra=None, args=()):
+    """Invoke ``parse_channel`` from install.sh in isolation.
+
+    We source the script after stubbing out ``main`` to a no-op, then call
+    ``parse_channel`` with the provided argv. ``env_extra`` lets a caller
+    set ``CCC_FROM`` (or explicitly unset it) for the child shell.
+    Returns the function's stdout, stripped.
+    """
+    env = os.environ.copy()
+    # Default: clear any inherited CCC_FROM so tests aren't polluted.
+    env.pop("CCC_FROM", None)
+    if env_extra:
+        for k, v in env_extra.items():
+            if v is None:
+                env.pop(k, None)
+            else:
+                env[k] = v
+    # install.sh's trailing `main` invocation is guarded by a
+    # `BASH_SOURCE != $0` check, so sourcing it from `bash -c` defines the
+    # functions without running the installer.
+    bash_program = (
+        f'source "{INSTALL_SCRIPT}"; '
+        'parse_channel "$@"'
+    )
+    result = subprocess.run(
+        ["bash", "-c", bash_program, "bash", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        f"parse_channel exited {result.returncode}\n"
+        f"STDOUT: {result.stdout!r}\nSTDERR: {result.stderr!r}"
+    )
+    return result.stdout.strip()
 
 
 class TestInstallScript(unittest.TestCase):
@@ -52,6 +90,63 @@ class TestInstallScript(unittest.TestCase):
             0,
             f"shellcheck failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
         )
+
+
+class TestParseChannel(unittest.TestCase):
+    """Channel resolution: --from=<flag> > CCC_FROM env > 'unknown'."""
+
+    def test_no_input_defaults_to_unknown(self):
+        self.assertEqual(_run_parse_channel(), "unknown")
+
+    def test_env_var_only(self):
+        self.assertEqual(
+            _run_parse_channel(env_extra={"CCC_FROM": "hn"}),
+            "hn",
+        )
+
+    def test_flag_only(self):
+        self.assertEqual(
+            _run_parse_channel(args=("--from=readme",)),
+            "readme",
+        )
+
+    def test_flag_overrides_env_var(self):
+        self.assertEqual(
+            _run_parse_channel(
+                env_extra={"CCC_FROM": "hn"},
+                args=("--from=readme",),
+            ),
+            "readme",
+        )
+
+    def test_garbage_env_var_falls_back_to_unknown(self):
+        self.assertEqual(
+            _run_parse_channel(env_extra={"CCC_FROM": "bogus-channel"}),
+            "unknown",
+        )
+
+    def test_garbage_flag_falls_back_to_unknown(self):
+        self.assertEqual(
+            _run_parse_channel(args=("--from=bogus-channel",)),
+            "unknown",
+        )
+
+    def test_all_documented_channels_round_trip(self):
+        for channel in (
+            "readme",
+            "landing-hero",
+            "hn",
+            "ph",
+            "devto",
+            "yt",
+            "gh-trending",
+            "unknown",
+        ):
+            with self.subTest(channel=channel):
+                self.assertEqual(
+                    _run_parse_channel(env_extra={"CCC_FROM": channel}),
+                    channel,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #45.

## Summary

Adds `scripts/install.sh` and a matching README curl one-liner so a fresh
macOS user with the `claude` CLI on PATH can go from zero to
`localhost:8090` in a single command.

## Locked decisions (verbatim from #45)

1. **Install location:** `~/.ccc/claude-command-center` — hidden, matches the launchd + `~/.claude/` convention this repo already uses.
2. **Brew tap deferred.** This PR ships `scripts/install.sh` and the README curl line only. The homebrew-ccc tap and release-tag Action come as a follow-up once a tag-publish workflow exists to keep the formula fresh automatically.
3. **Linux:** detect and exit fast with a one-line message pointing at the (forthcoming) Docker issue (#54). No half-Linux support.
4. **Service install:** foreground only. The script must not invoke `./run.sh --install-service`; coupling install with a launchd registration surprises new users and tangles `SECURITY.md` considerations.
5. **`?from=<channel>` attribution preserved now.** Script accepts the channel via query string or `--from=<channel>` flag and persists it to `~/.claude/command-center/install-source` so the telemetry feature (#48) inherits the signal when it ships. Enum: `readme`, `landing-hero`, `hn`, `ph`, `devto`, `yt`, `gh-trending`, `unknown`. Default `unknown`.

## How I verified

- `bash -n scripts/install.sh` — syntax clean.
- `python3 -m unittest tests.test_install_script -v` — 4 tests, 3 pass, 1 skipped (shellcheck not installed on this box; the test skips rather than fails by design).
- `python3 -m unittest tests.test_smoke` — all 94 existing smoke tests still pass; import-time correctness intact.
- Exercised the `parse_channel` function in isolation:
  - no args -> `unknown`
  - `--from=hn` -> `hn`
  - `--from=garbage` -> `unknown`
  - `--from=readme`, `--from=landing-hero` -> preserved verbatim
- README diff: the first Quickstart code fence is now the curl one-liner; the old `git clone && ./run.sh` block moved under a new "From source" subsection. The `--install-service` paragraph below is untouched.

## Out of scope (per locked decision 2)

- `homebrew-ccc` tap / Formula
- Release-tag GitHub Action that opens formula PRs
- Any service-install side effect from the install script

## Test plan

- [ ] Curl-pipe install on a clean macOS box with only Xcode CLT + `claude` CLI lands on `localhost:8090` in under 60s.
- [ ] Missing `python3` -> single-line error, non-zero exit.
- [ ] Missing `claude` CLI -> single-line error, non-zero exit.
- [ ] Re-running on an already-installed box does `git pull`, not a second clone.
- [ ] On Linux the script exits cleanly with the macOS-only message.
- [ ] `?from=hn` lands `hn` in `~/.claude/command-center/install-source`; `?from=garbage` lands `unknown`.