### PR TITLE
feat(spawn): worktree toggle for codex+antigravity, fix gc-reader input leak

### DIFF
--- a/changelog.d/added-worktree-codex-antigravity-2026-05-25.md
+++ b/changelog.d/added-worktree-codex-antigravity-2026-05-25.md
@@ -1,0 +1,1 @@
+**Worktree spawns for Codex and Antigravity.** The `🌿 worktree` toggle is now enabled for every engine in the new-session row (previously only Claude and Gemini). `/api/sessions/spawn[-codex|-antigravity]` accept a `worktree` boolean; when set, a fresh `feat/<slug>` worktree is created off the launch cwd and the engine runs there.

--- a/changelog.d/fixed-gc-reader-input-leak-2026-05-25.md
+++ b/changelog.d/fixed-gc-reader-input-leak-2026-05-25.md
@@ -1,0 +1,1 @@
+**Group chat reader no longer leaks events from the previous conversation.** Opening a group chat now stops the active conversation/spawn SSE streams; otherwise in-flight events kept appending below the reader's input row, looking like content "from another conversation" slipping into the bottom of the input box.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-command-center"
-version = "4.3.2.1"
+version = "4.4.0"
 description = "A local command center for Claude Code that doesn't care how your agents were launched."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.py
+++ b/server.py
@@ -11,7 +11,7 @@ Usage:
     PORT=9000 ./run.sh       # custom port
 """
 
-__version__ = "4.3.2.1"
+__version__ = "4.4.0"
 
 import ast
 import base64
@@ -15910,8 +15910,12 @@ def spawn_session_gemini(prompt, name=None, cwd=None, repo_path=None, worktree=F
     return {"ok": True, "pid": proc.pid, "name": session_name, "log": str(log_path)}
 
 
-def spawn_session_antigravity(prompt, name=None, cwd=None, repo_path=None, model=None):
-    """Spawn a headless AGY print-mode run and return tracking info."""
+def spawn_session_antigravity(prompt, name=None, cwd=None, repo_path=None, worktree=False, model=None):
+    """Spawn a headless AGY print-mode run and return tracking info.
+
+    If `worktree=True`, create a fresh git worktree off the launch cwd on a
+    `feat/<slug>` branch (same shape as the Claude path) and run AGY there.
+    """
     prompt = _strip_ccc_session_state_instruction(prompt or "")
     if not prompt:
         return {"ok": False, "error": "missing prompt"}
@@ -15939,6 +15943,17 @@ def spawn_session_antigravity(prompt, name=None, cwd=None, repo_path=None, model
             }
         model_to_use = settings_result.get("model") or model_to_use
 
+    worktree_path = None
+    worktree_branch = None
+    if worktree:
+        try:
+            worktree_path, worktree_branch = _create_worktree_for_spawn(
+                spawn_cwd, session_name,
+            )
+            spawn_cwd = worktree_path
+        except RuntimeError as e:
+            return {"ok": False, "error": f"worktree creation failed: {e}"}
+
     cmd = _antigravity_command_words(resolved)
     user_args = cmd[1:]
     if (
@@ -15958,6 +15973,8 @@ def spawn_session_antigravity(prompt, name=None, cwd=None, repo_path=None, model
     cmd.extend(["-p", prompt])
 
     log_fh = open(log_path, "w")
+    if worktree_path:
+        _run_worktree_init_hook(worktree_path, ctx["repo_path"], session_name, log_fh)
     try:
         proc = subprocess.Popen(
             cmd,
@@ -16013,7 +16030,7 @@ def spawn_session_antigravity(prompt, name=None, cwd=None, repo_path=None, model
         engine="antigravity",
         model=model_to_use,
     )
-    return {
+    resp = {
         "ok": True,
         "pid": proc.pid,
         "name": session_name,
@@ -16021,6 +16038,10 @@ def spawn_session_antigravity(prompt, name=None, cwd=None, repo_path=None, model
         "via": "antigravity-spawn",
         "model": model_to_use,
     }
+    if worktree_path:
+        resp["worktree_path"] = worktree_path
+        resp["worktree_branch"] = worktree_branch
+    return resp
 
 
 def _resume_session_antigravity_app(session_id, text):
@@ -16436,7 +16457,7 @@ def spawn_session(prompt, name=None, cwd=None, repo_path=None, worktree=False, m
     return resp
 
 
-def spawn_session_codex(prompt, name=None, cwd=None, repo_path=None, model=None):
+def spawn_session_codex(prompt, name=None, cwd=None, repo_path=None, worktree=False, model=None):
     """Spawn a headless Codex CLI run and return tracking info.
 
     Mirrors `spawn_session` but invokes the Codex CLI's `exec`
@@ -16449,6 +16470,9 @@ def spawn_session_codex(prompt, name=None, cwd=None, repo_path=None, model=None)
 
     The spawned subprocess requires an explicit cwd or repo_path. Codex `--cd`
     is set so the agent's workspace root matches that concrete directory.
+
+    If `worktree=True`, create a fresh git worktree off the launch cwd on a
+    `feat/<slug>` branch (same shape as the Claude path) and run codex there.
 
     Returns the same shape as spawn_session:
       {ok: True,  pid, name, log}                       — success
@@ -16475,6 +16499,17 @@ def spawn_session_codex(prompt, name=None, cwd=None, repo_path=None, model=None)
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / log_filename
 
+    worktree_path = None
+    worktree_branch = None
+    if worktree:
+        try:
+            worktree_path, worktree_branch = _create_worktree_for_spawn(
+                spawn_cwd, session_name,
+            )
+            spawn_cwd = worktree_path
+        except RuntimeError as e:
+            return {"ok": False, "error": f"worktree creation failed: {e}"}
+
     cmd = [
         bin_path, "exec",
         "--json",
@@ -16488,6 +16523,8 @@ def spawn_session_codex(prompt, name=None, cwd=None, repo_path=None, model=None)
     cmd.extend(["--", prompt])
 
     log_fh = open(log_path, "w")
+    if worktree_path:
+        _run_worktree_init_hook(worktree_path, ctx["repo_path"], session_name, log_fh)
     proc = subprocess.Popen(
         cmd,
         stdin=subprocess.DEVNULL,
@@ -16521,7 +16558,11 @@ def spawn_session_codex(prompt, name=None, cwd=None, repo_path=None, model=None)
         engine="codex",
     )
 
-    return {"ok": True, "pid": proc.pid, "name": session_name, "log": str(log_path)}
+    resp = {"ok": True, "pid": proc.pid, "name": session_name, "log": str(log_path)}
+    if worktree_path:
+        resp["worktree_path"] = worktree_path
+        resp["worktree_branch"] = worktree_branch
+    return resp
 
 
 _COLOR_PALETTE = [
@@ -25789,6 +25830,7 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
                             name=name,
                             cwd=spawn_cwd,
                             repo_path=payload.get("repo_path"),
+                            worktree=worktree_flag,
                             model=model,
                         )
                     elif engine == "antigravity":
@@ -25797,6 +25839,7 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
                             name=name,
                             cwd=spawn_cwd,
                             repo_path=payload.get("repo_path"),
+                            worktree=worktree_flag,
                             model=model,
                         )
                     else:
@@ -25868,6 +25911,7 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
                         name=name,
                         cwd=str(cwd_resolved) if cwd_resolved else None,
                         repo_path=payload.get("repo_path"),
+                        worktree=bool(payload.get("worktree")),
                         model=model,
                     )
                     # Resolver-side failures (binary not found, CCC_CODEX_BIN
@@ -25985,6 +26029,7 @@ class CommandCenterHandler(http.server.BaseHTTPRequestHandler):
                         name=name,
                         cwd=str(cwd_resolved) if cwd_resolved else None,
                         repo_path=payload.get("repo_path"),
+                        worktree=bool(payload.get("worktree")),
                         model=model,
                     )
                     if result.get("code") == "antigravity_unavailable":

--- a/static/app.js
+++ b/static/app.js
@@ -7077,6 +7077,13 @@
       renderSidebar(filterConversations($convSearch.value));
     }
 
+    // Stop the conv/spawn SSE streams for the previous conversation. They
+    // append into #conversationsView — the same node the reader mounts into
+    // — so any in-flight event would land below the reader's input row and
+    // look like content "from another conversation" leaking in.
+    try { if (typeof stopConvStream === 'function') stopConvStream(); } catch (_) {}
+    try { if (typeof stopSpawnStream === 'function') stopSpawnStream(); } catch (_) {}
+
     const view = document.getElementById('conversationsView');
     if (!view) return;
 
@@ -19427,7 +19434,9 @@
     return '/api/sessions/spawn';
   }
   function spawnSupportsWorktree(engine) {
-    return engine === 'claude' || engine === 'gemini';
+    // pkood orchestrates remote agents and has its own workspace contract,
+    // so it doesn't participate in the CCC-managed git-worktree flow.
+    return engine === 'claude' || engine === 'gemini' || engine === 'codex' || engine === 'antigravity';
   }
   function spawnUsesLogPlaceholder(engine) {
     return engine === 'codex' || engine === 'gemini' || engine === 'antigravity';

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1466,6 +1466,7 @@ class TestRepoContextHelpers(unittest.TestCase):
                 name=None,
                 cwd=None,
                 repo_path=None,
+                worktree=False,
                 model="gpt-test",
             )
         finally:
@@ -1641,7 +1642,7 @@ class TestRepoContextHelpers(unittest.TestCase):
         self.assertTrue(hasattr(server, "spawn_session_codex"))
         import inspect
         sig = inspect.signature(server.spawn_session_codex)
-        self.assertEqual(list(sig.parameters), ["prompt", "name", "cwd", "repo_path", "model"])
+        self.assertEqual(list(sig.parameters), ["prompt", "name", "cwd", "repo_path", "worktree", "model"])
 
     def test_spawn_session_gemini_exists(self):
         """`spawn_session_gemini` must exist alongside the other engines


### PR DESCRIPTION
Salvaged the stranded `feat/on-group-chats-...` worktree onto current main (it had forked 43 commits back, pre-`app.js` refactor).

## What
- **spawn:** `/api/sessions/spawn-codex` and `/spawn-antigravity` now accept a `worktree` boolean — fresh `feat/<slug>` worktree off launch cwd, same shape as the Claude path. UI 🌿 toggle enabled for every engine.
- **gc-reader:** `openGroupChatReader` stops active conv/spawn SSE streams before mounting, so in-flight events stop leaking into the reader's node.

## Notes
- Only conflicts on cherry-pick were the version string — resolved to `4.4.0` (minor, adds API surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amirfish1/claude-command-center/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->