### PR TITLE
Add Back to CCC link to group-chat-live for PWA standalone mode

### DIFF
--- a/static/group-chat-live.html
+++ b/static/group-chat-live.html
@@ -446,6 +446,10 @@
     </div>
     <button class="btn btn-primary" onclick="openCreateModal()">+ New Chat</button>
     <button class="btn btn-sm" onclick="refreshAll()">&#x21BB; Refresh</button>
+    <!-- Shown only in a PWA/standalone window (see init script): there a new
+         tab cannot open, so this is the only way back to the dashboard. In a
+         normal browser tab it stays hidden and behaviour is unchanged. -->
+    <a class="btn btn-sm" id="backToCccBtn" href="/" title="Back to the CCC dashboard" style="display:none">&#8592; CCC</a>
   </div>
 </div>
 
@@ -1148,6 +1152,20 @@
   });
 
   /* ── Init ── */
+  // The dashboard opens this page in a new tab. A new tab cannot open inside
+  // an installed PWA (standalone display mode), which would strand the user
+  // here with no way back. Reveal the Back-to-CCC link only in that case so
+  // normal browser-tab behaviour is left untouched.
+  (function revealBackInStandalone() {
+    var standalone =
+      (window.matchMedia && window.matchMedia('(display-mode: standalone)').matches) ||
+      window.navigator.standalone === true;
+    if (standalone) {
+      var back = document.getElementById('backToCccBtn');
+      if (back) back.style.display = '';
+    }
+  })();
+
   fetchChats().then(function() { startPolling(); });
 
 })();


### PR DESCRIPTION
## What

The standalone group-chat live view (`/group-chat-live.html`) has no way back to the dashboard. The sidebar entry opens it in a new tab, so in a normal browser you just close the tab to return. Installed as a PWA that breaks down: a standalone window has no new tab to open into and no browser chrome, so once you land on this page there is no route back to CCC.

This adds a small "Back to CCC" link to the top bar that points at `/`. It is hidden by default and only appears when the page is running standalone, detected via `display-mode: standalone` (and `navigator.standalone` on iOS). In a normal browser tab nothing changes, so existing behaviour is untouched.

## Why

When CCC is installed as a PWA and you open the live group-chat view, there is no back button, no tab strip, and no address bar. The only way out is force-quitting the app. This is a tiny bit of UI to cover that dead end, scoped so it never affects the browser-tab flow.

## Testing

- Normal browser tab: the link stays hidden, behaviour unchanged.
- Installed PWA (standalone display mode): a "Back to CCC" link shows in the top bar and returns to the dashboard.

One file, 18 lines, no new dependencies.
