### PR TITLE
ci(cla): wire PERSONAL_ACCESS_TOKEN for fork-PR signatures

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,9 +21,13 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # PERSONAL_ACCESS_TOKEN is optional — only needed if you want
-          # signatures stored in a different repo. Leaving it unset stores
-          # signatures in this repo's `cla-signatures` branch.
+          # PERSONAL_ACCESS_TOKEN is required when using remote-organization-name
+          # / remote-repository-name (as we do here to store signatures in the
+          # cla-signatures branch). Create a classic PAT with `contents: write`
+          # (repo scope) on a maintainer account and add it as a repository secret
+          # named PERSONAL_ACCESS_TOKEN. See the contributor-assistant action
+          # README for details on writing signatures to a remote repo/org.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/v1/cla.json'
           path-to-document: 'https://github.com/amirfish1/claude-command-center/blob/main/CLA.md'


### PR DESCRIPTION
The CLA action is configured with `remote-organization-name` / `remote-repository-name`, so signatures are written to the `cla-signatures` branch. That write path requires `PERSONAL_ACCESS_TOKEN` — the default `GITHUB_TOKEN` can't push to the signatures store — so signatures from fork PRs were silently not recorded.

Passes the secret through and documents how to mint it (classic PAT, `repo` scope, on a maintainer account, added as repo secret `PERSONAL_ACCESS_TOKEN`).

Re-sliced from a larger combined branch to contain only the `cla.yml` change.