### PR TITLE
fix(sessions): gate Claude liveness sidecars on freshness

### DIFF
--- a/server.py
+++ b/server.py
@@ -2618,6 +2618,16 @@ def _live_engine_session_ids():
 # is a safe backstop. Older, untouched rows skip the probe entirely.
 _LIVE_MTIME_WINDOW = 600
 
+# A Claude liveness sidecar (a hook-written marker in SIDECAR_STATE_DIR) only
+# proves the session is live while it is FRESH. The hooks never delete these
+# markers on session end, and an interactive Claude session carries no
+# resume-arg on its command line for the live-process scan to refute — so a
+# stale marker would otherwise pin a long-dead session "live" indefinitely
+# (observed: sessions idle for days still flagged live). Treat a marker older
+# than this window as dead. Tunable: larger keeps idle-but-open sessions lit
+# longer; smaller tracks active work more tightly.
+_SIDECAR_LIVE_WINDOW = 1800
+
 
 def _archive_session_is_live(session_id):
     """A session is "live" if any sidecar marker exists for it (Claude only),
@@ -2642,9 +2652,17 @@ def _archive_session_is_live(session_id):
         or _is_kilo_session(session_id)
     )
     if not is_non_claude_engine and SIDECAR_STATE_DIR.is_dir():
+        # Only a FRESH sidecar proves liveness — a stale one is a dead session's
+        # leftover marker (see _SIDECAR_LIVE_WINDOW). stat() instead of exists()
+        # keeps the syscall count identical while giving us the mtime to gate on.
+        now = time.time()
         try:
             for suffix in (".json", "_writes", "_in_flight.json", "_needs_approval.json"):
-                if (SIDECAR_STATE_DIR / f"{session_id}{suffix}").exists():
+                try:
+                    st = (SIDECAR_STATE_DIR / f"{session_id}{suffix}").stat()
+                except (OSError, ValueError):
+                    continue
+                if (now - st.st_mtime) < _SIDECAR_LIVE_WINDOW:
                     return True
         except OSError:
             pass

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -120,6 +120,40 @@ class TestServerImports(unittest.TestCase):
         self.assertEqual(server._ship_classify_remaining("snapshot.js"), "infra")
         self.assertEqual(server._ship_classify_remaining("apps/x/page.tsx"), "review")
 
+    def test_stale_sidecar_does_not_count_as_live(self):
+        """A Claude liveness sidecar only counts while fresh. The hooks never
+        delete these markers on session end, so a stale marker must NOT keep a
+        long-dead session flagged live (regression: sessions idle for days were
+        still reported is_live)."""
+        for mod in ("server", "morning", "morning_store"):
+            sys.modules.pop(mod, None)
+        server = importlib.import_module("server")
+        sid = "11111111-2222-3333-4444-555555555555"  # not a real engine session
+        with tempfile.TemporaryDirectory() as d:
+            dpath = pathlib.Path(d)
+            engine_patches = [
+                mock.patch.object(server, name, return_value=False)
+                for name in ("_is_codex_session", "_is_cursor_session",
+                             "_is_gemini_session", "_is_antigravity_session",
+                             "_is_kilo_session")
+            ]
+            with mock.patch.object(server, "SIDECAR_STATE_DIR", dpath), \
+                 mock.patch.object(server, "_live_engine_session_ids", return_value=set()):
+                for p in engine_patches:
+                    p.start()
+                try:
+                    marker = dpath / f"{sid}.json"
+                    marker.write_text("{}")
+                    # Fresh marker → live.
+                    self.assertTrue(server._archive_session_is_live(sid))
+                    # Stale marker (older than the window) → not live.
+                    old = time.time() - (server._SIDECAR_LIVE_WINDOW + 600)
+                    os.utime(marker, (old, old))
+                    self.assertFalse(server._archive_session_is_live(sid))
+                finally:
+                    for p in engine_patches:
+                        p.stop()
+
     def test_ship_index_attribution_is_wired_and_degrades(self):
         """The conversation-index attribution layer is defined, the verdict +
         ship-flow consult it, and a missing/erroring index degrades silently to


### PR DESCRIPTION
### Problem
`is_live` over-reports for Claude sessions. Interactive Claude sessions carry no resume-arg on their command line, so `_archive_session_is_live` treats a hook-written sidecar marker in `SIDECAR_STATE_DIR` as the *sole* liveness signal. The hooks (`stop.py`, `post-tool-use.py`, …) write those markers but **nothing deletes them on session end** — so a session that ran days ago keeps its markers and stays `is_live=true` forever.

Observed on a real machine: **13 sessions reported live, but only 3 had a running `claude` process** — the other 10 had sidecars last modified 3–5 days ago.

### Fix
Gate the sidecar check on freshness: a marker older than `_SIDECAR_LIVE_WINDOW` (30 min, tunable) is treated as dead. Implementation notes:
- Uses `stat()` instead of `exists()`, so the **syscall count is unchanged** — `tests/test_perf_budget.py` still passes.
- Non-Claude engines already ignore the sidecar (their liveness comes from the live-process scan), so they're unaffected.
- Read-side only — no files are deleted. (Sidecar accumulation/cleanup is a separate, optional follow-up.)

Added a regression test (`test_stale_sidecar_does_not_count_as_live`) — TestCase-style so it runs under the current `unittest discover` CI.

Tunable trade-off: a larger window keeps idle-but-open sessions lit longer; smaller tracks active work more tightly. 30 min keeps a session idle ~20 min live while culling multi-day phantoms. Happy to adjust to your preference.