### PR TITLE
Show Fable's % contribution to weekly usage on the throughput chart

### DIFF
--- a/changelog.d/added-throughput-fable-contribution-2026-07-08.md
+++ b/changelog.d/added-throughput-fable-contribution-2026-07-08.md
@@ -1,0 +1,1 @@
+Added a "Fable % of weekly" dashed line to the main throughput chart's weekly overlay, showing Fable's actual cumulative contribution to the weekly quota (token share × cumulative actual %) alongside the existing "if opus only" hypothetical.

--- a/static/throughput.html
+++ b/static/throughput.html
@@ -1270,6 +1270,10 @@
                   <span class="legend-color" style="height:2px;border-radius:0;border-top:2px dashed #94a3b8;background:transparent;"></span>
                   <span style="color:#94a3b8;">Last week</span>
                 </div>
+                <div class="legend-item" id="fable-contribution-legend" style="display:none;">
+                  <span class="legend-color" style="height:2px;border-radius:0;border-top:2px dashed #f5c842;background:transparent;"></span>
+                  <span style="color:#f5c842;">Fable % of weekly</span>
+                </div>
               </div>
             </div>
           </div>
@@ -2935,6 +2939,46 @@
               opLbl.setAttribute('font-weight', 'bold'); opLbl.setAttribute('text-anchor', 'start');
               opLbl.setAttribute('font-family', 'var(--font-mono)'); opLbl.setAttribute('opacity', '0.8');
               opLbl.textContent = `${lastOpusV.toFixed(1)}% if opus`; svg.appendChild(opLbl);
+            }
+          }
+        }
+
+        // 7b. FABLE % OF WEEKLY — dashed gold line showing Fable's actual cumulative
+        // contribution to the weekly quota (share of total tokens × cumulative actual %).
+        const _fableRows = (summary.per_model || []).filter(m => (m.model || m.engine || '').toLowerCase().includes('fable'));
+        const _fableTok = _fableRows.reduce((s, m) => s + (m.raw_context_tokens || 0) + (m.output_tokens || 0), 0);
+        const _totalModelTok = (summary.per_model || []).reduce((s, m) => s + (m.raw_context_tokens || 0) + (m.output_tokens || 0), 0);
+        const _fableRatio = (_totalModelTok > 0 && _fableTok > 0) ? _fableTok / _totalModelTok : null;
+        let lastFableV = null, lastFableI = -1;
+        const cumFableVals = _fableRatio ? cumActVals.map(v => {
+          if (v == null) return null;
+          return v * _fableRatio;
+        }) : [];
+        const fableContribLegend = document.getElementById('fable-contribution-legend');
+        if (fableContribLegend) fableContribLegend.style.display = _fableRatio ? 'flex' : 'none';
+        if (_fableRatio) {
+          let fp = '', fpS = false;
+          cumFableVals.forEach((fv, i) => {
+            if (fv == null) return;
+            const x = xScale(i + 1), y = yPct(fv);
+            fp += fpS ? `L ${x} ${y} ` : `M ${x} ${y} `;
+            fpS = true;
+            lastFableV = fv; lastFableI = i;
+          });
+          if (fp) {
+            const fableLine = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            fableLine.setAttribute('d', fp); fableLine.setAttribute('fill', 'none');
+            fableLine.setAttribute('stroke', '#f5c842'); fableLine.setAttribute('stroke-width', '1.5');
+            fableLine.setAttribute('stroke-dasharray', '3,2'); fableLine.setAttribute('opacity', '0.75');
+            svg.appendChild(fableLine);
+            if (lastFableI >= 0) {
+              const fx = xScale(lastFableI + 1), fy = yPct(lastFableV);
+              const fableLbl = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+              fableLbl.setAttribute('x', fx + 6); fableLbl.setAttribute('y', fy + 14);
+              fableLbl.setAttribute('fill', '#f5c842'); fableLbl.setAttribute('font-size', '10px');
+              fableLbl.setAttribute('font-weight', 'bold'); fableLbl.setAttribute('text-anchor', 'start');
+              fableLbl.setAttribute('font-family', 'var(--font-mono)'); fableLbl.setAttribute('opacity', '0.85');
+              fableLbl.textContent = `${lastFableV.toFixed(1)}% fable`; svg.appendChild(fableLbl);
             }
           }
         }

--- a/static/throughput.html
+++ b/static/throughput.html
@@ -2945,10 +2945,16 @@
 
         // 7b. FABLE % OF WEEKLY — dashed gold line showing Fable's actual cumulative
         // contribution to the weekly quota (share of total tokens × cumulative actual %).
+        // summary.per_model is a rolling last-7-days total, not aligned to the current
+        // billing period (selPeriodStart/selPeriodEnd) — so it can still hold pre-reset
+        // Fable rows even when the current period has none. Gate on weeklyData.fable_pct,
+        // which IS scoped to the current period, so the line only appears when Fable is
+        // actually active in this billing period.
+        const _fableActiveThisPeriod = weeklyData && weeklyData.fable_pct != null && weeklyData.fable_pct > 0;
         const _fableRows = (summary.per_model || []).filter(m => (m.model || m.engine || '').toLowerCase().includes('fable'));
         const _fableTok = _fableRows.reduce((s, m) => s + (m.raw_context_tokens || 0) + (m.output_tokens || 0), 0);
         const _totalModelTok = (summary.per_model || []).reduce((s, m) => s + (m.raw_context_tokens || 0) + (m.output_tokens || 0), 0);
-        const _fableRatio = (_totalModelTok > 0 && _fableTok > 0) ? _fableTok / _totalModelTok : null;
+        const _fableRatio = (_fableActiveThisPeriod && _totalModelTok > 0 && _fableTok > 0) ? _fableTok / _totalModelTok : null;
         let lastFableV = null, lastFableI = -1;
         const cumFableVals = _fableRatio ? cumActVals.map(v => {
           if (v == null) return null;

--- a/tests/test_throughput_fable_contribution_static.py
+++ b/tests/test_throughput_fable_contribution_static.py
@@ -12,3 +12,14 @@ def test_main_chart_shows_fable_weekly_contribution():
     assert "_fableRatio" in throughput_html
     assert "cumFableVals" in throughput_html
     assert "% fable" in throughput_html
+
+
+def test_fable_ratio_gated_on_current_period_activity():
+    throughput_html = pathlib.Path(PROJECT_ROOT, "static", "throughput.html").read_text(encoding="utf-8")
+
+    # summary.per_model is a rolling last-7-days total, not billing-period-scoped,
+    # so the ratio must be gated on the correctly-scoped weeklyData.fable_pct to
+    # avoid showing a contribution line from stale pre-reset Fable usage.
+    assert "_fableActiveThisPeriod" in throughput_html
+    assert "weeklyData.fable_pct != null && weeklyData.fable_pct > 0" in throughput_html
+    assert "_fableActiveThisPeriod && _totalModelTok > 0 && _fableTok > 0" in throughput_html

--- a/tests/test_throughput_fable_contribution_static.py
+++ b/tests/test_throughput_fable_contribution_static.py
@@ -1,0 +1,14 @@
+import pathlib
+
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_main_chart_shows_fable_weekly_contribution():
+    throughput_html = pathlib.Path(PROJECT_ROOT, "static", "throughput.html").read_text(encoding="utf-8")
+
+    assert 'id="fable-contribution-legend"' in throughput_html
+    assert "Fable % of weekly" in throughput_html
+    assert "_fableRatio" in throughput_html
+    assert "cumFableVals" in throughput_html
+    assert "% fable" in throughput_html


### PR DESCRIPTION
## What this changes

Adds a dashed gold "Fable % of weekly" line to the main usage graph on the throughput page (`static/throughput.html`), showing Fable's actual cumulative contribution to the weekly quota. It's computed as Fable's share of total per-model tokens applied to the existing cumulative actual-% curve — the same approximation approach already used by the "if opus only" hypothetical line in the same overlay. A matching legend entry (`#fable-contribution-legend`) only appears when there's Fable usage in the period.

## How I tested

- [x] `python3 -m unittest discover tests` passes (pre-existing failures in `test_smoke.py::test_hermes_rows_exempt_from_recency_windows` / `test_watchtower_worker_titles_*` are unrelated to this change — confirmed they fail identically on `main` before this diff)
- [x] Added `tests/test_throughput_fable_contribution_static.py` (static assertions on the new markup/JS, mirroring `test_throughput_model_breakdown_static.py`'s pattern)
- [x] Verified the edited `<script>` block parses cleanly (`new Function(...)` on the extracted source)

## Checklist

- [x] No new runtime dependencies (stdlib only, per project policy)
- [x] Subprocess calls use list-form args (no `shell=True`) — n/a, no subprocess changes
- [x] New endpoints that take paths from the body sandbox them — n/a, no new endpoints
- [x] Docs / README updated if user-facing behavior changed — n/a, self-contained chart change
- [x] `changelog.d/added-throughput-fable-contribution-2026-07-08.md` added (per this repo's changelog.d convention)

## Linked issue

Closes #


---
_Generated by [Claude Code](https://claude.ai/code/session_01PVxsMuxD9Jq7VGgkNYserv)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amirfish1/claude-command-center/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->