### PR TITLE
fix(ui): guard composer Enter handlers against IME composition

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -11287,7 +11287,7 @@
       // on-screen keyboard's return key is for line breaks, and Enter-to-send
       // fires constantly mid-typing (and when accepting autocorrect).
       const _expanded = $convInputBar && $convInputBar.classList.contains('is-composer-expanded');
-      if (e.key === 'Enter' && !e.shiftKey && !isTouchPrimary() && !(_expanded && !(e.ctrlKey || e.metaKey))) {
+      if (e.key === 'Enter' && !e.shiftKey && !e.isComposing && !isTouchPrimary() && !(_expanded && !(e.ctrlKey || e.metaKey))) {
         e.preventDefault();
         sendToTerminal();
       } else if (e.key === 'Escape') {
@@ -23732,7 +23732,7 @@
         }
         gcHumanInput.addEventListener('keydown', ev => {
           if (_gcMentionMenuHandleKeydown(ev)) return;
-          if (ev.key === 'Enter' && !ev.shiftKey && !isTouchPrimary()) {
+          if (ev.key === 'Enter' && !ev.shiftKey && !ev.isComposing && !isTouchPrimary()) {
             ev.preventDefault();
             sendHumanGcPost();
           }
@@ -35519,7 +35519,7 @@
       input.addEventListener('keydown', (ev) => {
         if (handleSlashCommandKeydown(input, ev)) return;
         if (recallLastComposerCommand(input, ev)) return;
-        if (ev.key === 'Enter' && !ev.shiftKey && !isTouchPrimary()) {
+        if (ev.key === 'Enter' && !ev.shiftKey && !ev.isComposing && !isTouchPrimary()) {
           ev.preventDefault();
           sendToTerminal(paneId);
         }


### PR DESCRIPTION
Fixes #106

## What broke

On macOS, the <kbd>Enter</kbd> that confirms an IME conversion (Japanese / Chinese / Korean) was sending the message instead of committing the candidate text. In practice a CJK user cannot type a single word without firing half-composed text at the session.

Reproduced on macOS in **both Chrome and Safari**. Windows is unaffected — its IME consumes the confirm-Enter so no `keydown` reaches the page, while on macOS the `keydown` does fire with `isComposing === true`.

## How this avoids it

Adds `&& !isComposing` to the three composer Enter handlers that were missing it:

| Line | Handler |
|---|---|
| `static/app.js:11290` | main composer (`sendToTerminal()`) |
| `static/app.js:23735` | group-chat human input (`sendHumanGcPost()`) |
| `static/app.js:35522` | right-pane composer (`sendToTerminal(paneId)`) |

This is the same guard the codebase already applies at `:7862`, `:8733` and `:55935` — the composers were simply the ones that got missed. No new pattern, no dependency, three characters of logic per site.

## Verification

- `node --check static/app.js` passes
- macOS + Chrome: conversion commits normally; Enter on a non-composing textarea still sends
- macOS + Safari: same
- Non-IME (plain ASCII) typing is unchanged — `isComposing` is only ever `true` mid-composition

No behavior change for any user who isn't mid-IME-composition.
