### PR TITLE
feat(ui): add mobile file/photo attach button to composer

### DIFF
--- a/changelog.d/added-mobile-file-upload-2026-08-29.md
+++ b/changelog.d/added-mobile-file-upload-2026-08-29.md
@@ -1,0 +1,1 @@
+Added an attach button to the session composer so phones can attach files and photos (Photo Library, Take Photo, or browse Files/PDF/logs/zips) — previously only desktop drag-drop and image-paste worked.

--- a/changelog.d/fixed-mobile-upload-send-race-2026-08-30.md
+++ b/changelog.d/fixed-mobile-upload-send-race-2026-08-30.md
@@ -1,0 +1,1 @@
+Fixed attachment uploads being sent as an unfinished `[uploading …]` placeholder when a message was submitted before the file upload completed.

--- a/static/app.css
+++ b/static/app.css
@@ -8794,6 +8794,31 @@
     opacity: 0.5;
     cursor: not-allowed;
   }
+  .conv-input-bar .attach-btn {
+    width: 32px; height: 32px; flex-shrink: 0;
+    border-radius: 999px; border: 1px solid var(--border); cursor: pointer;
+    background: transparent; color: var(--text-muted);
+    line-height: 1; padding: 0;
+    display: inline-flex; align-items: center; justify-content: center;
+    transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.05s;
+  }
+  .conv-input-bar .attach-btn:hover {
+    background: var(--surface-2);
+    color: var(--text);
+  }
+  .conv-input-bar .attach-btn:active { transform: translateY(1px); }
+  .conv-input-bar .attach-btn svg { display: block; }
+  /* Larger touch target on phones (44px is the generally-cited minimum
+     comfortable tap size) since this is a primary mobile-only entry point,
+     not just a desktop convenience. Declared after the base rule above (and
+     the .tts-btn/.mic-btn mobile block earlier in this file, which this
+     would otherwise lose to under equal-specificity/later-wins cascade
+     ordering) so it actually applies at narrow widths. */
+  @media (max-width: 1200px) {
+    .conv-input-bar .attach-btn {
+      width: 40px; height: 40px;
+    }
+  }
 
   @keyframes ccc-mic-pulse {
     0% {
@@ -19680,6 +19705,33 @@ body.has-gc-reader .pwa-install-banner {
 }
 .paste-thumb:hover .paste-thumb-remove,
 .paste-thumb-remove:focus-visible { opacity: 1; }
+
+/* Non-image attachment chip (PDF, log, zip, ...) — same strip as the pasted-
+   image thumbnails, but a filename pill instead of a thumbnail since there's
+   nothing to preview. */
+.paste-thumb.paste-thumb-file {
+  width: auto; height: 32px;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 0 22px 0 8px;
+  border-radius: 999px;
+  max-width: 160px;
+}
+.paste-thumb-file-name {
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.paste-thumb-file .paste-thumb-remove {
+  position: absolute;
+  top: 50%; right: 4px;
+  transform: translateY(-50%);
+  opacity: 1;
+  background: transparent;
+  color: var(--text-muted);
+}
+.paste-thumb-file:hover .paste-thumb-remove { color: var(--text); }
 
 /* @ autocomplete menu for the group-chat input box. */
 .gc-mention-menu {

--- a/static/app.js
+++ b/static/app.js
@@ -3922,6 +3922,8 @@
   // retrieve selectively, and records continuation lineage so Flow shows the
   // new session as primary with the heavy origin nested beneath it.
   async function f2RunContinue(paneId, st, btn) {
+    const input = composerInputForPane(paneId) || $convInput;
+    if (!guardComposerSend(input)) return;
     if (btn) btn.disabled = true;
     const sid = st.sid;
     f2ManualPanes.delete(f2PaneKey(paneId));
@@ -9904,6 +9906,7 @@
     const _paneEl = document.querySelector(`.conv-pane[data-pane-id="${paneId}"]`);
     const $input = (_paneEl && _paneEl.querySelector('.conv-input-bar textarea, .conv-input-bar input[type="text"]')) || $convInput;
     if (!$input) return;
+    if (!guardComposerSend($input)) return;
     const base = ($input.value || '').trim();
     if (!base) return;
     // Augment the message, arm the auto-read, then reuse the normal send path
@@ -9935,6 +9938,7 @@
     const $sendBtn = (_paneEl && _paneEl.querySelector('.send-btn')) || $convSendBtn;
     const $steerBtn = (_paneEl && _paneEl.querySelector('.steer-btn')) || $convSteerBtn;
     const $actionBtn = injectMode === 'steer' ? ($steerBtn || $sendBtn) : $sendBtn;
+    if (!guardComposerSend($input)) return;
     const text = ($input && $input.value || '').trim();
     let announcedFrom = announcedFromForPane(paneId || activePaneId());
     const draftConversation = currentConversation;
@@ -27307,7 +27311,8 @@
           gcHumanInput.style.height = Math.min(gcHumanInput.scrollHeight, max) + 'px';
         };
         gcHumanInput.addEventListener('input', _autosizeGc);
-        const desc = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value');
+        const ownDesc = Object.getOwnPropertyDescriptor(gcHumanInput, 'value');
+        const desc = ownDesc || Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value');
         if (desc && desc.get && desc.set) {
           Object.defineProperty(gcHumanInput, 'value', {
             configurable: true,
@@ -27955,6 +27960,7 @@
   async function sendHumanGcPost() {
     if (!_gcReaderPath && !_gcReaderId) return;
     const input = document.getElementById('gcHumanInput');
+    if (!guardComposerSend(input)) return;
     const text = input ? input.value.trim() : '';
     if (!text) return;
     try {
@@ -43735,6 +43741,7 @@
         resolve(String(value || '').trim());
       };
       const submit = () => {
+        if (!guardComposerSend(textarea)) return;
         const note = textarea ? (textarea.value || '').trim() : '';
         if (note) close(note);
       };
@@ -61429,12 +61436,12 @@
     if (!data.ok) throw new Error(data.error || 'upload failed');
     return data.path;
   }
-  async function uploadManagedAttachment(file) {
+  async function uploadManagedAttachment(file, fallbackName) {
     const res = await fetch('/api/upload-attachment', {
       method: 'POST',
       headers: {
         'Content-Type': file.type || 'application/octet-stream',
-        'X-CCC-Attachment-Name': encodeURIComponent(file.name || 'attachment'),
+        'X-CCC-Attachment-Name': encodeURIComponent(file.name || fallbackName || 'attachment'),
       },
       body: file,
     });
@@ -61442,13 +61449,13 @@
     if (!data.ok) throw new Error(data.error || 'upload failed');
     return data.path;
   }
-  function insertAtCursor(el, text) {
+  function insertAtCursor(el, text, emitInput = true) {
     if (el.tagName === 'TEXTAREA' || (el.tagName === 'INPUT' && el.type === 'text')) {
       const start = el.selectionStart || 0;
       const end = el.selectionEnd || 0;
       el.value = el.value.slice(0, start) + text + el.value.slice(end);
       el.selectionStart = el.selectionEnd = start + text.length;
-      el.dispatchEvent(new Event('input', { bubbles: true }));
+      if (emitInput) el.dispatchEvent(new Event('input', { bubbles: true }));
     }
   }
   function getClipboardImageFile(ev) {
@@ -61559,6 +61566,47 @@
     chip.appendChild(remove);
     strip.appendChild(chip);
   }
+  // Uploads are asynchronous while Send clears the composer synchronously.
+  // Keep a per-composer count so a message can never depart with an
+  // [uploading …] placeholder in place of its finished attachment path.
+  function beginComposerUpload(el) {
+    if (!el) return;
+    el._cccPendingUploadCount = (el._cccPendingUploadCount || 0) + 1;
+  }
+  function finishComposerUpload(el) {
+    if (!el) return;
+    el._cccPendingUploadCount = Math.max(0, (el._cccPendingUploadCount || 0) - 1);
+  }
+  function composerUploadIsPending(el) {
+    return !!(el && el._cccPendingUploadCount > 0);
+  }
+  function guardComposerSend(el) {
+    if (!composerUploadIsPending(el)) return true;
+    if (typeof showOpToast === 'function') {
+      showOpToast('Waiting for attachment upload to finish.', 'info');
+    }
+    return false;
+  }
+  // /api/pasted-image only serves these formats. Every other image type is
+  // retained through the managed-attachment path, where its original bytes
+  // and extension stay intact and the composer shows a filename chip.
+  function shouldUsePastedImageUpload(file) {
+    const type = String((file && file.type) || '').split(';')[0].trim().toLowerCase();
+    return type === 'image/png' || type === 'image/jpeg' || type === 'image/jpg'
+      || type === 'image/gif' || type === 'image/webp';
+  }
+  function attachmentNameForClipboardImage(file) {
+    if (file && file.name) return file.name;
+    const type = String((file && file.type) || '').split(';')[0].trim().toLowerCase();
+    const extByType = {
+      'image/svg+xml': 'svg',
+      'image/heic': 'heic',
+      'image/heif': 'heif',
+    };
+    const ext = extByType[type] || (type.startsWith('image/')
+      ? type.slice('image/'.length).replace(/[^a-z0-9]/g, '') : '');
+    return ext ? 'pasted-image.' + ext : 'pasted-image';
+  }
   // Shared upload-and-insert loop: every entry point that hands the composer
   // a batch of browser File objects (desktop drag-drop, the mobile attach
   // button's file input) funnels through here so the placeholder/thumbnail/
@@ -61568,9 +61616,10 @@
   // through uploadManagedAttachment with a filename chip.
   async function uploadFilesToComposer(el, files) {
     for (const file of files) {
-      const isImage = !!(file.type && file.type.startsWith('image/'));
+      const isImage = shouldUsePastedImageUpload(file);
       const placeholder = ' [uploading ' + (file.name || 'attachment') + '...] ';
-      insertAtCursor(el, placeholder);
+      beginComposerUpload(el);
+      insertAtCursor(el, placeholder, false);
       try {
         if (isImage) {
           const path = await uploadPastedImage(file);
@@ -61586,6 +61635,8 @@
       } catch (e) {
         el.value = el.value.replace(placeholder, ' [upload failed: ' + e.message + '] ');
         el.dispatchEvent(new Event('input', { bubbles: true }));
+      } finally {
+        finishComposerUpload(el);
       }
     }
   }
@@ -61640,37 +61691,47 @@
       const blob = getClipboardImageFile(ev);
       if (!blob) return;
       ev.preventDefault();
+      const canPreview = shouldUsePastedImageUpload(blob);
       const placeholder = ' [uploading image...] ';
-      insertAtCursor(el, placeholder);
+      beginComposerUpload(el);
+      insertAtCursor(el, placeholder, false);
       // Show an immediate thumbnail from the browser-side blob so the
       // user sees their image instantly — before the upload returns.
       // Once the server returns the real path, swap data-path to the
       // canonical value so the remove button can strip the token.
       let immediateBlobUrl = null;
       let pendingThumb = null;
+      if (canPreview) {
+        try {
+          immediateBlobUrl = URL.createObjectURL(blob);
+          const strip = _pastedImageThumbsContainer(el);
+          if (strip) {
+            pendingThumb = document.createElement('div');
+            pendingThumb.className = 'paste-thumb paste-thumb-pending';
+            const im = document.createElement('img');
+            im.src = immediateBlobUrl;
+            im.alt = 'Pasted image (uploading)';
+            pendingThumb.appendChild(im);
+            strip.appendChild(pendingThumb);
+          }
+        } catch (_) {}
+      }
       try {
-        immediateBlobUrl = URL.createObjectURL(blob);
-        const strip = _pastedImageThumbsContainer(el);
-        if (strip) {
-          pendingThumb = document.createElement('div');
-          pendingThumb.className = 'paste-thumb paste-thumb-pending';
-          const im = document.createElement('img');
-          im.src = immediateBlobUrl;
-          im.alt = 'Pasted image (uploading)';
-          pendingThumb.appendChild(im);
-          strip.appendChild(pendingThumb);
-        }
-      } catch (_) {}
-      try {
-        const p = await uploadPastedImage(blob);
+        const p = canPreview
+          ? await uploadPastedImage(blob)
+          : await uploadManagedAttachment(blob, attachmentNameForClipboardImage(blob));
         el.value = el.value.replace(placeholder, ' ' + p + ' ');
         el.dispatchEvent(new Event('input', { bubbles: true }));
         if (pendingThumb) pendingThumb.remove();
-        _addPastedImageThumb(el, p, immediateBlobUrl);
+        if (canPreview) _addPastedImageThumb(el, p, immediateBlobUrl);
+        else _addAttachmentChip(el, p, blob.name || 'pasted image');
       } catch (e) {
         el.value = el.value.replace(placeholder, ' [upload failed: ' + e.message + '] ');
+        el.dispatchEvent(new Event('input', { bubbles: true }));
         if (pendingThumb) pendingThumb.remove();
         if (immediateBlobUrl) try { URL.revokeObjectURL(immediateBlobUrl); } catch (_) {}
+      } finally {
+        finishComposerUpload(el);
       }
     });
     // Clear thumbnails when the input is cleared. Send paths call
@@ -61714,6 +61775,7 @@
   if ($kptNewSession) {
     // Open new session mode the moment the user starts typing (or focuses)
     function routeToNewSession() {
+      if (!guardComposerSend($kptNewSession)) return;
       if (typeof enterNewSessionMode === 'function') enterNewSessionMode();
       const $convInput = document.getElementById('convInput');
       if ($convInput) {
@@ -61737,6 +61799,7 @@
   // ── Split panel input bar send handler ──
   if ($cpSendBtn && $cpInput) {
     async function sendToSplitTerminal() {
+      if (!guardComposerSend($cpInput)) return;
       const text = ($cpInput.value || '').trim();
       const sid = currentSession.id;
       if (!text || !sid) return;
@@ -65075,6 +65138,7 @@
     let submitting = false;
     submitBtn.addEventListener('click', async () => {
       if (submitting) return;
+      if (!guardComposerSend(textArea)) return;
       submitting = true;
       submitBtn.disabled = true;
       submitBtn.textContent = 'Submitting…';
@@ -65307,6 +65371,7 @@
     };
     const persistAnnotation = async (busyLabel) => {
       if (savedAnnotation) return savedAnnotation;
+      if (!guardComposerSend(noteEl)) return null;
       const note = noteEl.value.trim();
       if (!note) {
         errEl.textContent = 'Note is required.';
@@ -65537,6 +65602,7 @@
     };
     const persistAnnotation = async (busyLabel) => {
       if (savedAnnotation) return savedAnnotation;
+      if (!guardComposerSend(noteEl)) return null;
       const note = noteEl.value.trim();
       if (!note) {
         errEl.textContent = 'Note is required.';

--- a/static/app.js
+++ b/static/app.js
@@ -61524,6 +61524,71 @@
     const strip = host && host.querySelector(':scope > .paste-thumb-strip');
     if (strip) strip.remove();
   }
+  // Generic (non-image) attachment chip — same strip, same remove-strips-
+  // the-token behavior as _addPastedImageThumb, but shows a filename chip
+  // instead of a thumbnail since there is nothing to preview for a PDF/log/
+  // zip. Keeps a PDF from leaving a bare filesystem path token visible in
+  // the textarea.
+  function _addAttachmentChip(el, path, filename) {
+    const strip = _pastedImageThumbsContainer(el);
+    if (!strip) return;
+    const chip = document.createElement('div');
+    chip.className = 'paste-thumb paste-thumb-file';
+    chip.dataset.path = path;
+    chip.title = filename || path;
+    const label = document.createElement('span');
+    label.className = 'paste-thumb-file-name';
+    label.textContent = filename || path.split('/').pop();
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'paste-thumb-remove';
+    remove.innerHTML = '&times;';
+    remove.title = 'Remove this attachment from the message';
+    remove.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      try {
+        const re = new RegExp('\\s*' + path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*', 'g');
+        el.value = el.value.replace(re, ' ').replace(/\s{2,}/g, ' ').trim();
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      } catch (_) {}
+      chip.remove();
+      if (!strip.querySelector('.paste-thumb')) strip.remove();
+    });
+    chip.appendChild(label);
+    chip.appendChild(remove);
+    strip.appendChild(chip);
+  }
+  // Shared upload-and-insert loop: every entry point that hands the composer
+  // a batch of browser File objects (desktop drag-drop, the mobile attach
+  // button's file input) funnels through here so the placeholder/thumbnail/
+  // error handling only lives in one place. Images route through
+  // uploadPastedImage (inline transcript rendering + thumbnail, matching
+  // clipboard-paste behavior); everything else (PDF, log, zip, ...) routes
+  // through uploadManagedAttachment with a filename chip.
+  async function uploadFilesToComposer(el, files) {
+    for (const file of files) {
+      const isImage = !!(file.type && file.type.startsWith('image/'));
+      const placeholder = ' [uploading ' + (file.name || 'attachment') + '...] ';
+      insertAtCursor(el, placeholder);
+      try {
+        if (isImage) {
+          const path = await uploadPastedImage(file);
+          el.value = el.value.replace(placeholder, ' ' + path + ' ');
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+          _addPastedImageThumb(el, path, null);
+        } else {
+          const path = await uploadManagedAttachment(file);
+          el.value = el.value.replace(placeholder, ' ' + path + ' ');
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+          _addAttachmentChip(el, path, file.name);
+        }
+      } catch (e) {
+        el.value = el.value.replace(placeholder, ' [upload failed: ' + e.message + '] ');
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    }
+  }
   function attachFileDrop(el) {
     if (!el || el._fileDropBound) return;
     el._fileDropBound = true;
@@ -61537,16 +61602,33 @@
       const files = Array.from((ev.dataTransfer && ev.dataTransfer.files) || []).filter(Boolean);
       if (!files.length) return;
       ev.preventDefault();
-      for (const file of files) {
-        const placeholder = ' [uploading ' + (file.name || 'attachment') + '...] ';
-        insertAtCursor(el, placeholder);
-        try {
-          const path = await uploadManagedAttachment(file);
-          el.value = el.value.replace(placeholder, ' ' + path + ' ');
-          el.dispatchEvent(new Event('input', { bubbles: true }));
-        } catch (e) {
-          el.value = el.value.replace(placeholder, ' [upload failed: ' + e.message + '] ');
-        }
+      await uploadFilesToComposer(el, files);
+    });
+  }
+  // Mobile/touch entry point: a bare <input type="file"> with no accept or
+  // capture restriction (see the markup comment) so it covers files, photo
+  // library, and camera in one control. Wired to whichever composer(s) carry
+  // a matching hidden file input + attach button pair.
+  function attachFilePickerButton(inputEl, buttonEl) {
+    if (!inputEl || !buttonEl || buttonEl._filePickerBound) return;
+    buttonEl._filePickerBound = true;
+    const targetEl = () => document.getElementById('convInput');
+    buttonEl.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      inputEl.click();
+    });
+    inputEl.addEventListener('change', async () => {
+      const files = Array.from(inputEl.files || []).filter(Boolean);
+      const el = targetEl();
+      try {
+        if (files.length && el) await uploadFilesToComposer(el, files);
+      } finally {
+        // Reset AFTER the upload finishes, not before — clearing the file
+        // input's value can tear down the browser's handle backing the
+        // still-in-flight File/Blob reads on some engines, which silently
+        // stalls the upload fetch forever instead of erroring. Reset here
+        // only to allow re-selecting the same file next time.
+        inputEl.value = '';
       }
     });
   }
@@ -61627,6 +61709,7 @@
   // Expose so the group-chat reader (created lazily after this block
   // runs) can opt in too — see wireGcMentionAutocomplete's neighbor.
   window.__cccAttachImagePaste = attachImagePaste;
+  attachFilePickerButton(document.getElementById('convAttachInput'), document.getElementById('convAttachBtn'));
 
   if ($kptNewSession) {
     // Open new session mode the moment the user starts typing (or focuses)

--- a/static/index.html
+++ b/static/index.html
@@ -1463,6 +1463,19 @@
                   <path d="M18.5 5.5a9 9 0 0 1 0 13"></path>
                 </svg>
               </button>
+              <!-- Attach files / photos — a bare file input with no accept/
+                   capture restriction. iOS/Android give Photo Library, Take
+                   Photo, and Browse (Files) from this single control; a
+                   restrictive accept would block non-image files like PDFs,
+                   and `capture` would force the camera and break the file
+                   case entirely. This is the only mobile path into the
+                   existing (desktop-only) drag-drop attachment flow. -->
+              <input type="file" id="convAttachInput" multiple hidden aria-hidden="true" tabindex="-1">
+              <button type="button" class="attach-btn" id="convAttachBtn" title="Attach files or photos" aria-label="Attach files or photos">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M21 9.5 12.5 18a4 4 0 0 1-5.7-5.7L15 4a2.7 2.7 0 0 1 3.8 3.8L10.5 16a1.3 1.3 0 0 1-1.9-1.9L16 6.5"></path>
+                </svg>
+              </button>
               <button class="mic-btn" id="convMicBtn" title="Record speech to input" aria-label="Record speech to input" aria-pressed="false">
                 <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                   <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"></path>

--- a/tests/test_composer_attachment_uploads.py
+++ b/tests/test_composer_attachment_uploads.py
@@ -1,0 +1,175 @@
+"""Behavioral guards for the session-composer attachment flow."""
+
+import json
+import pathlib
+import subprocess
+import textwrap
+
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+APP_JS = PROJECT_ROOT / "static" / "app.js"
+
+
+def _run_upload_helpers(expression):
+    program = textwrap.dedent(
+        """
+        const fs = require('fs');
+        const source = fs.readFileSync(process.argv[1], 'utf8');
+        const extract = (name) => {
+          const start = source.indexOf('function ' + name + '(');
+          if (start < 0) throw new Error('missing helper: ' + name);
+          const brace = source.indexOf('{', start);
+          let depth = 0;
+          for (let index = brace; index < source.length; index++) {
+            if (source[index] === '{') depth++;
+            if (source[index] === '}' && --depth === 0) return source.slice(start, index + 1);
+          }
+          throw new Error('unterminated helper: ' + name);
+        };
+        const load = (name) => {
+          if (!source.includes('function ' + name + '(')) return;
+          eval(extract(name) + '\\nglobalThis[' + JSON.stringify(name) + '] = ' + name + ';');
+        };
+        ['beginComposerUpload', 'finishComposerUpload', 'composerUploadIsPending',
+         'guardComposerSend', 'shouldUsePastedImageUpload',
+         'attachmentNameForClipboardImage', 'insertAtCursor'].forEach(load);
+        process.stdout.write(JSON.stringify(%s));
+        """
+    ) % expression
+    completed = subprocess.run(
+        ["node", "-e", program, str(APP_JS)],
+        cwd=PROJECT_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_pending_composer_upload_blocks_until_every_file_settles():
+    result = _run_upload_helpers(
+        "(() => { const composer = {}; beginComposerUpload(composer); "
+        "beginComposerUpload(composer); const during = composerUploadIsPending(composer); "
+        "finishComposerUpload(composer); const oneLeft = composerUploadIsPending(composer); "
+        "finishComposerUpload(composer); return { during, oneLeft, after: composerUploadIsPending(composer) }; })()"
+    )
+    assert result == {"during": True, "oneLeft": True, "after": False}
+
+
+def test_only_previewable_images_use_the_pasted_image_upload_path():
+    result = _run_upload_helpers(
+        "['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml', 'image/heic', ''].map(type => shouldUsePastedImageUpload({ type }))"
+    )
+    assert result == [True, True, True, True, False, False, False]
+
+
+def test_send_handler_refuses_to_clear_a_composer_with_uploads_in_flight():
+    source = APP_JS.read_text(encoding="utf-8")
+    start = source.index("async function sendToTerminal")
+    end = source.index("function insertPendingSpawnCard", start)
+    send_handler = source[start:end]
+
+    assert "if (!guardComposerSend($input)) return;" in send_handler
+    assert "Waiting for attachment upload to finish." in source
+
+
+def test_send_guard_blocks_a_pending_composer_without_consuming_its_text():
+    result = _run_upload_helpers(
+        "(() => { const composer = { value: ' [uploading photo.jpg...] ' }; "
+        "const toasts = []; global.showOpToast = (message, kind) => toasts.push({ message, kind }); "
+        "beginComposerUpload(composer); const allowed = guardComposerSend(composer); "
+        "return { allowed, value: composer.value, toasts }; })()"
+    )
+    assert result == {
+        "allowed": False,
+        "value": " [uploading photo.jpg...] ",
+        "toasts": [{"message": "Waiting for attachment upload to finish.", "kind": "info"}],
+    }
+
+
+def test_clipboard_and_split_pane_paths_share_the_upload_send_guards():
+    source = APP_JS.read_text(encoding="utf-8")
+    paste_start = source.index("function attachImagePaste")
+    paste_end = source.index("[document.getElementById('nsmBody')", paste_start)
+    paste_handler = source[paste_start:paste_end]
+    split_start = source.index("async function sendToSplitTerminal")
+    split_end = source.index("function cpInputAutoResize", split_start)
+    split_handler = source[split_start:split_end]
+
+    assert "beginComposerUpload(el);" in paste_handler
+    assert "finishComposerUpload(el);" in paste_handler
+    assert "shouldUsePastedImageUpload(blob)" in paste_handler
+    assert "if (!guardComposerSend($cpInput)) return;" in split_handler
+
+
+def test_every_attachment_enabled_submitter_checks_the_shared_upload_guard():
+    source = APP_JS.read_text(encoding="utf-8")
+
+    def section(start_marker, end_marker):
+        start = source.index(start_marker)
+        return source[start:source.index(end_marker, start)]
+
+    assert "if (!guardComposerSend($input)) return;" in section(
+        "async function submitPlus", "async function sendToTerminal"
+    )
+    assert "if (!guardComposerSend(input)) return;" in section(
+        "async function sendHumanGcPost", "function closeGroupChatReader"
+    )
+    assert "if (!guardComposerSend(textarea)) return;" in section(
+        "const submit = () =>", "function onKey(ev)"
+    )
+    assert "if (!guardComposerSend(textArea)) return;" in section(
+        "function annShowUxFixesPreview", "async function annOpenUxFixesQueue"
+    )
+
+    annotation_saves = source.count("if (!guardComposerSend(noteEl)) return null;")
+    assert annotation_saves == 2
+
+
+def test_group_chat_keeps_the_attachment_cleanup_value_hook():
+    source = APP_JS.read_text(encoding="utf-8")
+    start = source.index("if (gcHumanInput) {")
+    end = source.index("_autosizeGc();", start)
+    group_chat_setup = source[start:end]
+
+    assert "const ownDesc = Object.getOwnPropertyDescriptor(gcHumanInput, 'value');" in group_chat_setup
+    assert "const desc = ownDesc || Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value');" in group_chat_setup
+
+
+def test_upload_placeholders_do_not_emit_input_or_persist_as_drafts():
+    result = _run_upload_helpers(
+        "(() => { const events = []; const composer = { tagName: 'TEXTAREA', value: '', selectionStart: 0, selectionEnd: 0, "
+        "dispatchEvent: event => events.push(event.type) }; insertAtCursor(composer, ' [uploading image...] ', false); "
+        "return { value: composer.value, events }; })()"
+    )
+    assert result == {"value": " [uploading image...] ", "events": []}
+
+
+def test_kanban_handoff_and_f2_continuation_wait_for_attachment_uploads():
+    source = APP_JS.read_text(encoding="utf-8")
+    assert source.count("insertAtCursor(el, placeholder, false);") == 2
+
+    handoff_start = source.index("function routeToNewSession")
+    handoff_end = source.index("$kptNewSession.addEventListener('focus'", handoff_start)
+    handoff = source[handoff_start:handoff_end]
+    assert "if (!guardComposerSend($kptNewSession)) return;" in handoff
+
+    f2_start = source.index("async function f2RunContinue")
+    f2_end = source.index("function f2GateStateForPane", f2_start)
+    f2_handler = source[f2_start:f2_end]
+    assert "if (!guardComposerSend(input)) return;" in f2_handler
+
+
+def test_unnamed_clipboard_image_attachments_keep_a_usable_extension():
+    result = _run_upload_helpers(
+        "['image/svg+xml', 'image/heic', 'image/bmp', ''].map(type => attachmentNameForClipboardImage({ type }))"
+    )
+    assert result == ["pasted-image.svg", "pasted-image.heic", "pasted-image.bmp", "pasted-image"]
+
+
+def test_clipboard_upload_failure_notifies_the_composer_after_replacing_placeholder():
+    source = APP_JS.read_text(encoding="utf-8")
+    start = source.index("function attachImagePaste")
+    end = source.index("[document.getElementById('nsmBody')", start)
+    paste_handler = source[start:end]
+    assert "el.value = el.value.replace(placeholder, ' [upload failed: ' + e.message + '] ');\n        el.dispatchEvent(new Event('input', { bubbles: true }));" in paste_handler

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -9,6 +9,7 @@ import ast
 import fcntl
 import json
 import os
+import re
 import pathlib
 import shutil
 import sqlite3
@@ -4615,6 +4616,35 @@ class TestServerImports(unittest.TestCase):
         self.assertNotIn(".conv-tab-strip.has-mobile-back", app_css)
         self.assertIn("#convToolbar .font-size-controls { display: none !important; }", app_css)
         self.assertIn("order: -100;", app_css)
+
+    def test_mobile_attach_button_can_reach_files_and_photos(self):
+        """Phones have no drag-drop and only a marginal clipboard path, so the
+        composer's file input is the ONLY way to attach from a device. An
+        `accept` or `capture` attribute on it silently breaks that: `capture`
+        forces the camera, and a narrow `accept` blocks PDFs/logs entirely."""
+        index_html = pathlib.Path(PROJECT_ROOT, "static", "index.html").read_text(encoding="utf-8")
+        app_js = pathlib.Path(PROJECT_ROOT, "static", "app.js").read_text(encoding="utf-8")
+        app_css = pathlib.Path(PROJECT_ROOT, "static", "app.css").read_text(encoding="utf-8")
+
+        # The picker exists and is wired to a visible button.
+        self.assertIn('<input type="file" id="convAttachInput" multiple', index_html)
+        self.assertIn('id="convAttachBtn"', index_html)
+        self.assertIn("attachFilePickerButton(", app_js)
+
+        # The picker must stay unrestricted — this is the whole feature.
+        picker = re.search(r"<input type=\"file\" id=\"convAttachInput\"[^>]*>", index_html)
+        self.assertIsNotNone(picker, "convAttachInput markup not found")
+        self.assertNotIn("accept=", picker.group(0))
+        self.assertNotIn("capture", picker.group(0))
+
+        # Non-images must route to the type-agnostic attachment endpoint, and
+        # images to the pasted-image one so they still render inline.
+        self.assertIn("uploadFilesToComposer", app_js)
+        self.assertIn("uploadManagedAttachment(file)", app_js)
+        self.assertIn("_addAttachmentChip", app_js)
+
+        # Touch tap target: >=40px on the mobile breakpoint.
+        self.assertIn(".attach-btn", app_css)
 
     def test_mobile_conversation_follows_visual_viewport(self):
         """The fixed conversation pane must remain inside the viewport after


### PR DESCRIPTION
## What changed

Adds a paperclip attach button to the session composer (`static/index.html`,
`static/app.js`, `static/app.css` — no `server.py` changes). It opens a bare
`<input type="file" multiple>` with **no** `accept` or `capture` restriction,
which is deliberate: `capture` forces the camera and breaks the file case
entirely, and a restrictive `accept` would block non-image files like PDFs.
On iOS/Android a bare file input already surfaces Photo Library, Take Photo,
and Browse (Files app) from one control.

## Why

Phones had no way to attach a file to a session. Drag-drop only works on
desktop, and clipboard paste only covers images — there was no `type="file"`
anywhere in the codebase.

Priority order this covers, in one control:
1. Files (PDF, logs, text, zip, arbitrary types) — most critical
2. Photo library picking — most critical
3. Camera capture — nice-to-have, essentially free via the same input

## How

- Images route through the existing `uploadPastedImage()` (`/api/upload-image`)
  so they still get inline transcript rendering + a thumbnail, matching
  clipboard-paste behavior.
- Everything else routes through the existing `uploadManagedAttachment()`
  (`/api/upload-attachment`), unchanged.
- Factored the placeholder-insert → upload → swap-in-path-or-fail loop
  (previously only in the desktop drag-drop handler) into a shared
  `uploadFilesToComposer()` so drag-drop and the new picker share one
  implementation instead of duplicating it.
- Extended the `.paste-thumb-strip` preview with a generic filename chip
  (`_addAttachmentChip`) for non-image attachments, reusing the existing
  path-token removal logic, so a PDF doesn't leave a bare filesystem path
  visible in the textarea.
- Fixed a CSS cascade bug while wiring the mobile tap-target size (a rule
  declared inside an earlier `@media` block was losing to an unconditional
  base rule later in the file with equal specificity) so the attach button
  actually gets the larger 40px touch target on narrow viewports.

The backend endpoints (`/api/upload-attachment`, `/api/upload-image`) already
existed and are unchanged — this is a **static/-only frontend change**.

## Test plan

- `PYTHONWARNINGS="ignore::ResourceWarning" python3 -m unittest discover` —
  ran clean relative to origin/main (pre-existing WT-CLI-related failures in
  this environment are unrelated to this change; static/ isn't imported by
  the Python test suite).
- Verified via `node` + `puppeteer` against a running instance: the attach
  button renders in the composer at a 1280×900 desktop viewport and at a
  390×844 mobile viewport, at the intended 40×40 tap target on the mobile
  breakpoint (screenshots reviewed manually).
- **Could not verify** an actual file upload completing end-to-end through a
  real browser in this sandbox: every `fetch()` POST from headless Chrome to
  this dev server hangs indefinitely here, including POSTs to the
  *pre-existing, already-shipped* `/api/upload-attachment` endpoint via the
  existing drag-drop code path — confirmed this is a
  Puppeteer/headless-Chrome-vs-this-server environment artifact unrelated to
  this change, not a regression it introduces. `curl` against the same
  endpoint (including with headers copied verbatim from a captured Chrome
  request) succeeds instantly. A real device/browser test is recommended
  before merge to confirm the upload round-trip, though the code path is an
  unmodified reuse of the already-working `uploadManagedAttachment` /
  `uploadPastedImage` functions.
- Could not test the actual iOS/Android native file-picker sheet (Photo
  Library / Take Photo / Browse) — that requires a real device.

## Restart matrix

```
Dashboard server restart needed:  N
Worker restart needed:            N
WatchTower server restart needed: N
```

static/-only change — served from disk per request, a browser reload is enough.