### PR TITLE
fix: create state files owner-only via umask 077

### DIFF
--- a/ccc_worker.py
+++ b/ccc_worker.py
@@ -396,6 +396,8 @@ def serve(path=None):
 
 
 def main(argv=None):
+    # State files, logs and transcripts hold secrets: create everything owner-only.
+    os.umask(0o077)
     parser = argparse.ArgumentParser(description="CCC persistent execution worker")
     parser.add_argument("--socket", help="Unix socket path")
     parser.add_argument(

--- a/changelog.d/security-owner-only-umask-2026-09-12.md
+++ b/changelog.d/security-owner-only-umask-2026-09-12.md
@@ -1,0 +1,1 @@
+Server and worker now set umask 077 at startup so state files, logs and transcript backups are created owner-only.

--- a/server.py
+++ b/server.py
@@ -37020,6 +37020,8 @@ _adopt_ccc_module("fleet_reco")
 _adopt_ccc_module("fleet_jobs")
 
 def main():
+    # State files, logs and transcripts hold secrets: create everything owner-only.
+    os.umask(0o077)
     import socketserver
     class ThreadedHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
         allow_reuse_address = True


### PR DESCRIPTION
**Problem:** `server.py` and `ccc_worker.py` create transcripts, compact backups, logs, and config under `~/.claude/command-center` using the process's default umask, which is world-readable on macOS (typically `022`). These files can hold secrets.

**Change:** Call `os.umask(0o077)` as the first statement in each entrypoint (`server.py:main()` and `ccc_worker.py:main()`) so every file CCC creates going forward is owner-only.

**How to verify:** Restart the server/worker, then `ls -l ~/.claude/command-center` — newly created files should show `-rw-------` instead of `-rw-r--r--`.

Note: `SECURITY.md` already tells users to `chmod 700` the directory manually; this makes new files owner-only by default instead of relying on that manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)